### PR TITLE
[RCL-151] civis api -> civis data science api

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: civis
-Title: R Client for the Civis Platform API
+Title: R Client for the Civis Data Science API
 Version: 0.9.0
 Authors@R: c(
   person("Bill", "Lattner", email = "wlattner@civisanalytics.com", role = c("cre", "aut")),

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Civis API Client
+Civis Data Science API Client
 ================
 [![Build Status](https://travis-ci.com/civisanalytics/civis-r-client.svg?token=E2j26hcJpSqCtyNqWd2B&branch=open-source)](https://travis-ci.com/civisanalytics/civis-r-client)
 
@@ -8,12 +8,12 @@ Introduction
 `civis` is an R package that helps analysts and developers interact with
 the Civis Platform. The package includes a set of tools around common
 workflows as well as a convenient interface to make requests directly to
-the Civis API.
+the Civis Data Science API.
 
 Installation
 ------------
 
-Installing and using `civis` requires a Civis API key.  Instructions
+Installing and using `civis` requires an API key.  Instructions
 for creating an API key can be found [here](https://civis.zendesk.com/hc/en-us/articles/216341583-Generating-an-API-Key).
 All API keys have a set expiration date and so a new key will need to be
 created at least every 30 days.
@@ -41,15 +41,15 @@ Usage
 
 `civis` includes functionality for both
 
-1. Making direct calls to the Platform API
+1. Making direct calls to the API
 2. Making single calls to accomplish a specific task (which may involve
-making multiple calls to the Platform API)
+making multiple calls to the API)
 
-Functions which make direct calls to the Platform API are prefixed with
-the name of the resource that the function accesses.  For example, the
-`users` resource encapsulates all the functionality of Platform regarding
-users.  We can make various calls to the `users` resource to get information
-about ourselves and our team.
+Functions which make direct calls to the API are prefixed with the name of the
+resource that the function accesses.  For example, the `users` resource
+encapsulates all the functionality of Platform regarding users.  We can make
+various calls to the `users` resource to get information about ourselves and our
+team.
 
 ```r
 # Data about me
@@ -61,7 +61,7 @@ my_team <- civis::users_list()
 team_members <- sapply(my_team, function(x) x$name)
 ```
 
-Many useful tasks will require making multiple direct calls to Platform.
+Many useful tasks will require making multiple direct calls to the API.
 In order to make this easier, `civis` includes a number of wrapper functions
 to make common tasks easier. For example, reading data from a table in
 Platform is as easy as
@@ -88,7 +88,7 @@ browseVignettes('civis')
 
 Updating
 --------
-The `civis` package automatically generates R functions and documentation to interact with the Civis Platform when the package installs. Periodically, the Civis Platform API is updated with new functionality. New functions can be generated to access these features automatically by reinstalling the `civis` package from CRAN.
+The `civis` package automatically generates R functions and documentation to interact with the Civis Platform when the package installs. Periodically, the Civis Data Science API is updated with new functionality. New functions can be generated to access these features automatically by reinstalling the `civis` package from CRAN.
 
 
 API Documentation
@@ -104,7 +104,7 @@ Contributions to the code are very welcome! Issues and bug reports can filed thr
 cd tools/integration_tests
 Rscript smoke_test.R
 ```
-Note, integration tests require a valid Civis API key to run, and my be slow.
+Note, integration tests require a valid API key to run, and my be slow.
 
 All contributors of code should include themselves in `DESCRIPTION` by adding
 the following object in the `Authors@R` section:


### PR DESCRIPTION
Changing `DESCRIPTION` and `README.md` to use "Civis Data Science API" instead of "Civis API" or "Civis Platform API."