### PR TITLE
[RCL-138] Add condition for empty_result_error

### DIFF
--- a/R/io.R
+++ b/R/io.R
@@ -38,11 +38,11 @@
 #'
 #' # Gracefully handle when read_civis.sql returns no rows
 #' query <- sql("SELECT * FROM table WHERE 1 = 2")
-#' tryCatch({
+#' mean_x <- tryCatch({
 #'   df <- read_civis(query, database = "my_database")
-#'   mean_x <- mean(df$x)
+#'   mean(df$x)
 #' }, empty_result_error = function(e) {
-#'   mean_x <- NA
+#'    NA
 #' })
 #' }
 #' @export

--- a/R/io.R
+++ b/R/io.R
@@ -35,6 +35,15 @@
 #' # Read a text file or csv from the files endpoint.
 #' id <- write_civis_file("my_csv.csv")
 #' df <- read_civis(id, using = read.csv)
+#'
+#' # Gracefully handle when read_civis.sql returns no rows
+#' query <- sql("SELECT * FROM table WHERE 1 = 2")
+#' tryCatch({
+#'   df <- read_civis(query, database = "my_database")
+#'   mean_x <- mean(df$x)
+#' }, empty_result_error = function(e) {
+#'   mean_x <- NA
+#' })
 #' }
 #' @export
 #' @family io
@@ -606,7 +615,11 @@ download_script_results <- function(script_id, run_id,
   script_results <- scripts_get_sql_runs(script_id, run_id)
   # Verify that the script actually generated output
   if (length(script_results[["output"]]) == 0) {
-    stop("Query produced no output.")
+    msg <- paste0("Query produced no output. ",
+                  "(script_id = ", script_id,
+                  ", run_id = ", run_id, ")")
+    cond <- condition(c("empty_result_error", "error"), msg, call = NULL)
+    stop(cond)
   }
   url <- script_results[["output"]][[1]][["path"]]
   args <- list(url)

--- a/man/read_civis.Rd
+++ b/man/read_civis.Rd
@@ -78,11 +78,11 @@ df <- read_civis(id, using = read.csv)
 
 # Gracefully handle when read_civis.sql returns no rows
 query <- sql("SELECT * FROM table WHERE 1 = 2")
-tryCatch({
+mean_x <- tryCatch({
   df <- read_civis(query, database = "my_database")
-  mean_x <- mean(df$x)
+  mean(df$x)
 }, empty_result_error = function(e) {
-  mean_x <- NA
+   NA
 })
 }
 }

--- a/man/read_civis.Rd
+++ b/man/read_civis.Rd
@@ -75,6 +75,15 @@ df <- read_civis(id)
 # Read a text file or csv from the files endpoint.
 id <- write_civis_file("my_csv.csv")
 df <- read_civis(id, using = read.csv)
+
+# Gracefully handle when read_civis.sql returns no rows
+query <- sql("SELECT * FROM table WHERE 1 = 2")
+tryCatch({
+  df <- read_civis(query, database = "my_database")
+  mean_x <- mean(df$x)
+}, empty_result_error = function(e) {
+  mean_x <- NA
+})
 }
 }
 \seealso{


### PR DESCRIPTION
This is adding behavior like [`civis-python`](https://github.com/civisanalytics/civis-python/blob/master/civis/io/_tables.py#L222) so users can catch the error raised when `read_civis` returns no rows.