### PR TITLE
FIX: Fixing a bad link on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Introduction
 the Civis Platform. The package includes a set of tools around common
 workflows as well as a convenient interface to make requests directly to
 the Civis Data Science API. See the [full documentation](https://civisanalytics.github.io/civis-r)
-and the [getting started guide](https://civisanalytics.github.io/civis-r/quick_start.html)
+and the [getting started guide](https://civisanalytics.github.io/civis-r/articles/quick_start.html)
 for more details.
 
 Installation


### PR DESCRIPTION
I missed `/articles` earlier when I updated the getting started guide!