### PR TITLE
[RCL-35] REF Linting

### DIFF
--- a/R/await.R
+++ b/R/await.R
@@ -92,13 +92,13 @@ await <- function(f, ...,
     status <- get_status(r$response)
 
     if (!is.null(.timeout)) {
-      running_time <- as.numeric(difftime(Sys.time(), start, units="secs"))
+      running_time <- as.numeric(difftime(Sys.time(), start, units = "secs"))
       if (running_time > .timeout) stop(civis_timeout_error(fname, list(...), status))
     }
 
     interval <- if (is.null(.interval)) interval_jitter(i) else .interval
     if (.verbose) {
-      pretty_time <- formatC(interval, digits=3, format = "fg")
+      pretty_time <- formatC(interval, digits = 3, format = "fg")
       msg <- paste0("Status: ", status, " @ ", Sys.time(),
                     ". Retry ", i, " in ", pretty_time, " seconds")
       message(msg)
@@ -139,7 +139,7 @@ await_all <- function(f, .x, ...,
     }
 
     if (!is.null(.timeout)) {
-      running_time <- as.numeric(difftime(Sys.time(), start, units="secs"))
+      running_time <- as.numeric(difftime(Sys.time(), start, units = "secs"))
       if (running_time > .timeout) {
         args <- c(list(.x), list(...))
         names(args)[1] <- names(formals(f))[1]
@@ -151,7 +151,7 @@ await_all <- function(f, .x, ...,
     interval <- if (is.null(.interval)) interval_jitter(i) else .interval
 
     if (.verbose) {
-      pretty_time <- formatC(interval, digits=3, format = "fg")
+      pretty_time <- formatC(interval, digits = 3, format = "fg")
       make_msg <- function(x) {
         msg <- paste0("Task: ", x, " Status: ", responses[[x]]$response[[.status_key]],
                       " @ ", Sys.time(),

--- a/R/civis_ml.R
+++ b/R/civis_ml.R
@@ -533,10 +533,10 @@ run_model <- function(template_id, name, arguments, notifications, verbose) {
 
   job <- do.call(scripts_post_custom, script_args)
   run <- scripts_post_custom_runs(job$id)
-  r <- tryCatch(await(scripts_get_custom_runs, id = job$id, run_id = run$id,
-                      .verbose = verbose),
-                civis_error = function(e) stop(civis_ml_error(e)),
-                error = function(e) stop(e))
+  tryCatch(await(scripts_get_custom_runs, id = job$id, run_id = run$id,
+                    .verbose = verbose),
+          civis_error = function(e) stop(civis_ml_error(e)),
+          error = function(e) stop(e))
   list(job_id = job$id, run_id = run$id)
 }
 

--- a/R/client_base.R
+++ b/R/client_base.R
@@ -1,7 +1,6 @@
-
 #' Print results from a Civis API call
 #'
-#' @param x A \code{civis_api} response. 
+#' @param x A \code{civis_api} response.
 #' @param ... Further arguments passed to \code{str}
 #'
 #' @examples
@@ -24,11 +23,11 @@ print.civis_api <- function(x, ...) {
 call_api <- function(verb, path, path_params, query_params, body_params) {
     url <- build_url(path, path_params)
     auth <- httr::authenticate(api_key(), "")
-    session <- utils::sessionInfo()
+
     # this works when call_api is used to download spec before package is installed
     pkg_version <- tryCatch(version(), error = function(e) "")
-    
-    user_str <- sprintf("civis-r/%s %s %s", as.character(pkg_version), 
+
+    user_str <- sprintf("civis-r/%s %s %s", as.character(pkg_version),
                         R.version$version.string, utils::sessionInfo()$platform)
     user_agent <- httr::user_agent(user_str)
 
@@ -43,24 +42,24 @@ call_api <- function(verb, path, path_params, query_params, body_params) {
 
     stop_for_status(response,
                     paste(response$request$method, response$request$url))
-    
-    if(response$status_code %in% c(204, 205)) {
+
+    if (response$status_code %in% c(204, 205)) {
       content <- list()
     } else {
       content <- try(httr::content(response), silent = TRUE)
     }
-    
+
     if (is.error(content)) {
       msg <- paste0("Unable to parse JSON from response")
       call <- build_function_name(verb, path)
       cond <- condition(c("civis_api_error", "civis_error", "error"), msg, call = call, response = response)
       stop(cond)
     }
-    
-    structure(content, 
+
+    structure(content,
               headers = httr::headers(response),
               response = response,
-              path = path, 
+              path = path,
               class = c("civis_api", class(content)))
 }
 

--- a/R/dbi-connection.R
+++ b/R/dbi-connection.R
@@ -63,7 +63,7 @@ setMethod(
 #' @export
 setGeneric("dbIsReadOnly",
   def = function(dbObj, ...) standardGeneric("dbIsReadOnly"),
-  valueClass="logical")
+  valueClass = "logical")
 
 #' @rdname DBI
 #' @inheritParams DBI::dbIsValid

--- a/R/generate_client.R
+++ b/R/generate_client.R
@@ -13,11 +13,11 @@ generate_client <- function(spec, IGNORE) {
   ign_regex <- paste0("^/", IGNORE)
   paths <- with(spec, paths[!grepl(ign_regex, names(paths))])
 
-  for(i in seq_along(paths)){
+  for (i in seq_along(paths)) {
     path <- paths[[i]]
-    for(j in seq_along(path)){
+    for (j in seq_along(path)) {
       verb <- path[[j]]
-      verb <- replace_ref(verb, spec, previous_ref="")
+      verb <- replace_ref(verb, spec, previous_ref = "")
       params <- parse_params(verb)
       path_name <- names(paths)[i]
       verb_name <- names(path)[j]
@@ -34,12 +34,12 @@ generate_client <- function(spec, IGNORE) {
 
 build_function_body <- function(verb, verb_name, path_name, params) {
   has_params <- length(params) > 0
-  path_params  <- if(has_params) with(params, name[http_location == "path"]) else NULL
-  query_params <- if(has_params) with(params, name[http_location == "query"]) else NULL
-  body_params  <- if(has_params) with(params, name[http_location == "body"]) else NULL
-  path_param_str  <- if(length(path_params) > 0) paste0(path_params, " = ", camel_to_snake(path_params), collapse = ", ") else ""
-  query_param_str <- if(length(query_params) > 0) paste0(query_params, " = ", camel_to_snake(query_params), collapse = ", ") else ""
-  body_param_str  <- if(length(body_params) > 0) paste0(body_params,  " = ", camel_to_snake(body_params),  collapse = ", ") else ""
+  path_params  <- if (has_params) with(params, name[http_location == "path"]) else NULL
+  query_params <- if (has_params) with(params, name[http_location == "query"]) else NULL
+  body_params  <- if (has_params) with(params, name[http_location == "body"]) else NULL
+  path_param_str  <- if (length(path_params) > 0) paste0(path_params, " = ", camel_to_snake(path_params), collapse = ", ") else ""
+  query_param_str <- if (length(query_params) > 0) paste0(query_params, " = ", camel_to_snake(query_params), collapse = ", ") else ""
+  body_param_str  <- if (length(body_params) > 0) paste0(body_params,  " = ", camel_to_snake(body_params),  collapse = ", ") else ""
 
    paste0(
     "  args <- as.list(match.call())[-1]\n",
@@ -47,8 +47,8 @@ build_function_body <- function(verb, verb_name, path_name, params) {
     "  path_params  <- list(", path_param_str,  ")\n",
     "  query_params <- list(", query_param_str, ")\n",
     "  body_params  <- list(", body_param_str,  ")\n",
-    "  path_params  <- path_params[match_params(path_params, args)]\n", 
-    "  query_params <- query_params[match_params(query_params, args)]\n", 
+    "  path_params  <- path_params[match_params(path_params, args)]\n",
+    "  query_params <- query_params[match_params(query_params, args)]\n",
     "  body_params  <- body_params[match_params(body_params, args)]\n",
     "  resp <- call_api(\"", verb_name, "\", path, path_params, query_params, body_params)\n\n",
     "  return(resp)\n\n }\n"
@@ -57,7 +57,7 @@ build_function_body <- function(verb, verb_name, path_name, params) {
 
 build_function_args <- function(params) {
   default_arg <- ifelse(params$required, "", " = NULL")
-  arg_str <- paste0(camel_to_snake(params$name), default_arg, collapse=", ")
+  arg_str <- paste0(camel_to_snake(params$name), default_arg, collapse = ", ")
   paste0(" <- function(", arg_str, ") {\n\n")
 }
 
@@ -83,27 +83,31 @@ build_docs <- function(verb) {
 build_params_docs <- function(verb) {
   params <- verb$parameters
   doc_str <- ""
-  params <- params[order(sapply(params, function(x){x$required}), decreasing=T)]
+  params <- params[order(sapply(params, function(x) x$required), decreasing = T)]
 
-  if(length(params) > 0){
-    for(i in seq_along(params)){
+  if (length(params) > 0) {
+    for (i in seq_along(params)) {
       param <- params[[i]]
-      if(is_obj(param)){
+      if (is_obj(param)) {
         p <- get_obj_properties(param)
         req <- param$schema$required
-        if(!is.null(req)){
+        if (!is.null(req)) {
           # see scripts_post_sql
           preq <- p[names(p) %in% req]
-          doc_str <- paste0(doc_str, write_properties(preq, "required", transform_name=camel_to_snake))
+          doc_str <- paste0(doc_str,
+            write_properties(preq, "required", transform_name = camel_to_snake))
 
           popt <- p[!(names(p) %in% req)]
-          doc_str <- paste0(doc_str, write_properties(popt, "optional", transform_name=camel_to_snake))
+          doc_str <- paste0(doc_str,
+            write_properties(popt, "optional", transform_name = camel_to_snake))
         } else {
-          doc_str <- paste0(doc_str, write_properties(p, get_req_str(param), transform_name=camel_to_snake))
+          doc_str <- paste0(doc_str,
+            write_properties(p, get_req_str(param), transform_name = camel_to_snake))
         }
-      } else if(is_array(param)){
+      } else if (is_array(param)) {
         p <- get_array_properties(param)
-        doc_str <- paste0(doc_str, write_properties(p, get_req_str(param), transform_name=camel_to_snake))
+        doc_str <- paste0(doc_str,
+          write_properties(p, get_req_str(param), transform_name = camel_to_snake))
       } else {
         name <- camel_to_snake(param$name)
         doc_str <- paste0(doc_str,
@@ -121,15 +125,15 @@ build_resp_docs <- function(verb) {
   # can be 200, 201, 202, 204.
   resp <- verb$responses[[1]]
   doc_str <- ""
-  if(length(resp) > 1){
-    if(is_array(resp)){
+  if (length(resp) > 1) {
+    if (is_array(resp)) {
       p <- get_array_properties(resp)
       doc_str <- paste0(doc_str, " An array containing the following fields:\n",
-                        write_properties(p, fmt="#' \\item{%s}{%s, %s%s}"))
-    } else if(is_obj(resp)){
+                        write_properties(p, fmt = "#' \\item{%s}{%s, %s%s}"))
+    } else if (is_obj(resp)) {
       p <- get_obj_properties(resp)
       doc_str <- paste0(doc_str, " A list containing the following elements:\n",
-                        write_properties(p, fmt="#' \\item{%s}{%s, %s%s}"))
+                        write_properties(p, fmt = "#' \\item{%s}{%s, %s%s}"))
     } else {
       doc_str <- "An undocumented HTTP response\n"
     }
@@ -139,9 +143,10 @@ build_resp_docs <- function(verb) {
   paste0("#' @return ", doc_str)
 }
 
-write_properties <- function(x, req_str="", fmt="#' @param %s %s %s. %s", doc_str="", transform_name=I) {
-  for(j in seq_along(x)){
-    if(is_nested(x[[j]])){
+write_properties <- function(x, req_str="", fmt="#' @param %s %s %s. %s",
+                             doc_str="", transform_name = I) {
+  for (j in seq_along(x)) {
+    if (is_nested(x[[j]])) {
       descr_str <- write_nested_docs(x[[j]])
     } else {
       descr_str <- get_descr_str(x[[j]])
@@ -155,18 +160,22 @@ write_properties <- function(x, req_str="", fmt="#' @param %s %s %s. %s", doc_st
 write_nested_docs <- function(x) {
   doc_str <- ""
   fmt <- "#' \\item %s %s, %s"
-  if(is_array(x)){
+  if (is_array(x)) {
     ps <- get_array_properties(x)
-    doc_str <- paste0(doc_str, "An array containing the following fields: \n#' \\itemize{\n")
-    for(i in seq_along(ps)){
-      doc_str <- paste0(doc_str, sprintf(fmt, names(ps)[i], ps[[i]]$type, get_descr_str(ps[[i]])), "\n")
+    doc_str <- paste0(doc_str,
+        "An array containing the following fields: \n#' \\itemize{\n")
+    for (i in seq_along(ps)) {
+      doc_str <- paste0(doc_str, sprintf(fmt, names(ps)[i], ps[[i]]$type,
+                                         get_descr_str(ps[[i]])), "\n")
     }
     doc_str <- paste0(doc_str, "#' }")
-  } else if (is_obj(x)){
+  } else if (is_obj(x)) {
     ps <- get_obj_properties(x)
-    doc_str <- paste0(doc_str, "A list containing the following elements: \n#' \\itemize{\n")
-    for(i in seq_along(ps)){
-      doc_str <- paste0(doc_str, sprintf(fmt, names(ps)[i], ps[[i]]$type, get_descr_str(ps[[i]])), "\n")
+    doc_str <- paste0(doc_str,
+        "A list containing the following elements: \n#' \\itemize{\n")
+    for (i in seq_along(ps)) {
+      doc_str <- paste0(doc_str,
+        sprintf(fmt, names(ps)[i], ps[[i]]$type, get_descr_str(ps[[i]])), "\n")
     }
     doc_str <- paste0(doc_str, "#' }")
   }
@@ -177,13 +186,13 @@ parse_params <- function(verb, spec) {
   params <- verb$parameters
   arg_names <- location <- required <- description <- type <- list()
 
-  for(i in seq_along(params)){
+  for (i in seq_along(params)) {
     param <- params[[i]]
 
     # Case 1: param is an obj
-    if(!is.null(param$schema)){
+    if (!is.null(param$schema)) {
       properties <- param$schema$properties
-      for(j in seq_along(properties)){
+      for (j in seq_along(properties)) {
         arg_names <- c(arg_names, names(properties)[[j]])
         descr_str <- get_descr_str(properties[[j]])
         description <- c(description, descr_str)
@@ -203,14 +212,14 @@ parse_params <- function(verb, spec) {
     }
   }
 
-  df <- data.frame(name=unlist(arg_names),
-                   http_location=unlist(location),
-                   required=unlist(required),
-                   description=unlist(description),
-                   type=unlist(type), stringsAsFactors = F)
+  df <- data.frame(name = unlist(arg_names),
+                   http_location = unlist(location),
+                   required = unlist(required),
+                   description = unlist(description),
+                   type = unlist(type), stringsAsFactors = FALSE)
 
   # Put required arguments first.
-  if(length(df) > 0) df <- df[order(df$required, decreasing = T), ]
+  if (length(df) > 0) df <- df[order(df$required, decreasing = TRUE), ]
   df
 }
 
@@ -224,16 +233,16 @@ replace_ref <- function(x, spec, previous_ref="") {
   for (i in seq_along(x)) {
     val <- x[[i]]
     key <- names(x)[i]
-    key <- if(is.null(key)) i else key
+    key <- if (is.null(key)) i else key
     if (is_ref(val)) {
-      if(!same_ref(previous_ref, val)){
+      if (!same_ref(previous_ref, val)) {
         ref_val <- get_ref(val, spec)
-        x_replaced[[key]] <- replace_ref(ref_val, spec=spec, previous_ref=val)
+        x_replaced[[key]] <- replace_ref(ref_val, spec = spec, previous_ref = val)
       } else {
         #x_replaced[[key]] <- val
       }
     } else if (is.list(val)) {
-      x_replaced[[key]] <- replace_ref(val, spec=spec, previous_ref=previous_ref)
+      x_replaced[[key]] <- replace_ref(val, spec = spec, previous_ref = previous_ref)
     } else {
       x_replaced[[key]] <- val
     }
@@ -246,7 +255,7 @@ is_ref <- function(x) {
 }
 
 same_ref <- function(parent, child) {
-  if(is_ref(parent) & is_ref(child)) parent$`$ref` == child$`$ref` else FALSE
+  if (is_ref(parent) & is_ref(child)) parent$`$ref` == child$`$ref` else FALSE
 }
 
 # ref is a list with key="$ref" and value="#/definitions/Objectx"
@@ -262,9 +271,9 @@ is_nested <- function(x) { is_array(x) | is_obj(x) }
 
 
 is_array <- function(x) {
-  if(!is.null(x$schema)){
+  if (!is.null(x$schema)) {
     flag <- (x$schema$type == "array") & (!is.null(x$schema$items$properties))
-  } else if(!is.null(x$type)){
+  } else if (!is.null(x$type)) {
     flag <- (x$type == "array") & !is.null(x$items$properties)
   } else {
     flag <- FALSE
@@ -273,9 +282,9 @@ is_array <- function(x) {
 }
 
 is_obj <- function(x) {
-  if(!is.null(x$schema)){
+  if (!is.null(x$schema)) {
     flag <- (x$schema$type == "object" & !is.null(x$schema$properties))
-  } else if(!is.null(x$type)){
+  } else if (!is.null(x$type)) {
     flag <- (x$type == "object" & !is.null(x$properties))
   } else {
     flag <- FALSE
@@ -284,29 +293,29 @@ is_obj <- function(x) {
 }
 
 get_descr_str <- function(x) {
-  if(!is.null(x$description)) x$description else ""
+  if (!is.null(x$description)) x$description else ""
 }
 
 get_req_str <- function(x) {
   doc_str <- ""
-  if(!is.null(x$required)){
-    doc_str <- if(x$required) "required" else "optional"
+  if (!is.null(x$required)) {
+    doc_str <- if (x$required) "required" else "optional"
   }
   doc_str
 }
 
 get_array_properties <- function(x) {
-  if(!is.null(x$schema)) x$schema$items$properties else x$items$properties
+  if (!is.null(x$schema)) x$schema$items$properties else x$items$properties
 }
 
 get_obj_properties <- function(x) {
-  if(!is.null(x$schema)) x$schema$properties else x$properties
+  if (!is.null(x$schema)) x$schema$properties else x$properties
 }
 
 returns_array <- function(verb, verb_name, path_name) {
-  if(verb_name == "get" & !endsWith(path_name, "}")) return(TRUE)
+  if (verb_name == "get" & !endsWith(path_name, "}")) return(TRUE)
   rtype <- verb$responses[[1]]$schema$type
-  if(!is.null(rtype) && (rtype == "array")) return(TRUE)
+  if (!is.null(rtype) && (rtype == "array")) return(TRUE)
   return(FALSE)
 }
 
@@ -315,11 +324,11 @@ returns_array <- function(verb, verb_name, path_name) {
 get_spec <- function() {
 
   # Skip retries whenever api_key not set (e.g. Travis, Appveyor, CRAN)
-  if(!inherits(try(api_key(), silent = TRUE), "try-error")){
-    api_spec <- try(call_api("get", path="/endpoints/", list(), list(), list()))
-    if(inherits(api_spec, "try-error")){
+  if (!inherits(try(api_key(), silent = TRUE), "try-error")) {
+    api_spec <- try(call_api("get", path = "/endpoints/", list(), list(), list()))
+    if (inherits(api_spec, "try-error")) {
       message("Downloading API specification from Civis failed, using cached API specification.")
-      
+
       # loads cached spec generated from 'tools/generate_default_client.R'
       load("R/sysdata.rda")
     } else {
@@ -333,6 +342,6 @@ get_spec <- function() {
 }
 
 write_client <- function(client_str, FILENAME) {
-  cat("", file=FILENAME)
-  cat(client_str, file=FILENAME, append=TRUE)
+  cat("", file = FILENAME)
+  cat(client_str, file = FILENAME, append = TRUE)
 }

--- a/R/reports.R
+++ b/R/reports.R
@@ -45,15 +45,15 @@ publish_rmd <- function(rmd_file, report_id=NULL, report_name=NULL,
   render_args[["input"]] <- rmd_file
 
   tryCatch({
-    temp_output <- tempfile(fileext=".html")
+    temp_output <- tempfile(fileext = ".html")
     if (is.null(render_args[["output_file"]])) {
       render_args[["output_file"]] <- temp_output
     }
     do.call(rmarkdown::render, render_args)
     publish_html(render_args[["output_file"]],
                  report_id, report_name,
-                 provide_api_key=provide_api_key,
-                 project_id=project_id)
+                 provide_api_key = provide_api_key,
+                 project_id = project_id)
   }, finally = {
     unlink(temp_output)
   })
@@ -84,11 +84,11 @@ publish_html <- function(html_file, report_id=NULL, report_name=NULL,
   html <- wrap_in_scrolling_div(html)
 
   if (is.null(report_id)) {
-    r <-  reports_post(code_body=html, name=report_name,
-                       provide_api_key=provide_api_key)
+    r <- reports_post(code_body = html, name = report_name,
+                      provide_api_key = provide_api_key)
   } else {
-    r <- reports_patch(report_id, code_body=html, name=report_name,
-                       provide_api_key=provide_api_key)
+    r <- reports_patch(report_id, code_body = html, name = report_name,
+                       provide_api_key = provide_api_key)
   }
 
   report_id <- r[["id"]]

--- a/tests/testthat/test-DBI.R
+++ b/tests/testthat/test-DBI.R
@@ -14,8 +14,8 @@ mock_read_civis <- function(...) iris
 mock_tables_list <- function(...) c("table_1", "table_2")
 mock_get_table_id <- function(...) 2757016
 mock_tables_get <- function(...) {
-  ret <- list(columns = list(list(name="col1", sqlType="integer"),
-                             list(name="col2", sqlType="integer")))
+  ret <- list(columns = list(list(name = "col1", sqlType = "integer"),
+                             list(name = "col2", sqlType = "integer")))
   class(ret) <- c("civis_api", "list")
   return(ret)
 }

--- a/tests/testthat/test_await.R
+++ b/tests/testthat/test_await.R
@@ -1,13 +1,16 @@
-context("Await")
+context("await")
 
 test_that("await captures success_state from status key", {
-  f <- function(x) if (x == 0) list(state="success", y = 2) else list(state = "fail", y = NULL)
-  expect_silent(r <- await(f, x = 0, .status_key = "state", .success_states = c("success", "fail")))
-  
+  f <- function(x) {
+    if (x == 0) list(state = "success", y = 2) else list(state = "fail", y = NULL)
+  }
+  expect_silent(r <- await(f, x = 0, .status_key = "state",
+                           .success_states = c("success", "fail")))
+
   expect_equal(r$state, "success")
   expect_equal(get_status(r), "success")
   expect_equal(r$y, 2)
-  
+
   r <- await(f, x = 1, .status_key = "state", .success_states = c("success", "fail"))
   expect_equal(r$state, "fail")
   expect_equal(get_status(r), "fail")
@@ -25,18 +28,19 @@ test_that("await calls f until terminal status", {
 test_that("await errors on timeout or if status_key not found", {
   msg <- "Timeout exceeded. Current status: running"
   f <- function(x) list(state = "running")
-  expect_error(await(f, x = 1, .status_key = "state", .success_states = c("this never occurs"), 
+  expect_error(await(f, x = 1, .status_key = "state",
+                     .success_states = c("this never occurs"),
                      .timeout = .001, .interval = .001), msg)
-  
+
   f <- function(x) list(x)
   msg <- "Cannot find status"
-  expect_error(await(f, x=1), msg)
+  expect_error(await(f, x = 1), msg)
 })
 
 test_that("await throws a civis_await_error with failure state", {
   g <- function(x) {
     if (x == 0) {
-      list(state = "success", y = 2) 
+      list(state = "success", y = 2)
     } else {
       list(state = "fail", y = NULL, error = "this failed on platform")
     }
@@ -50,7 +54,7 @@ test_that("await throws a civis_await_error with failure state", {
   expect_is(e, c("civis_await_error", "civis_error", "error"))
   msg <- "g(x = 1): this failed on platform"
   expect_equal(e$message, msg)
-  
+
   e2 <- tryCatch(await(g, x = 1, .success_states = "success", .error_states = "fail"),
                 "civis_error" = function(e) e)
   expect_equal(e, e2)
@@ -58,16 +62,16 @@ test_that("await throws a civis_await_error with failure state", {
 
 test_that("await throws a civis_timeout_error on timeout", {
   f <- function(x) list(state = "running")
-  
+
   msg <- "Timeout exceeded. Current status: running"
   expect_error(await(f, x = 0, .timeout = .001, .interval = .001), msg)
-  
+
   e <- tryCatch(await(f, x = 0, .timeout = .001, .interval = .001),
                 "civis_timeout_error" = function(e) e)
   expect_is(e, c("civis_await_error", "civis_error", "error"))
   msg <- "Timeout exceeded. Current status: running"
   expect_equal(e$message, msg)
-  
+
   e2 <- tryCatch(await(f, x = 0, .timeout = .001, .interval = .001),
                 "civis_error" = function(e) e)
   expect_equal(e, e2)
@@ -81,14 +85,14 @@ test_that("get_error returns error data for civis_error", {
       list(state = "fail", y = NULL, error = "this failed on platform")
     }
   }
-  
+
   e <- tryCatch(await(f, x = 1, .success_states = "success", .error_states = "fail"),
                 "civis_error" = function(e) e)
   e_data <- get_error(e)
   expect_equal(e_data$args, list(x = 1))
   expect_equal(e_data$f, "f")
   expect_equal(e_data$error, "this failed on platform")
-  
+
   e <- tryCatch(await(f, x = 0, .timeout = .001, .error_states = "fail"),
                 "civis_error" = function(e) e)
   e_data <- get_error(e)
@@ -100,18 +104,22 @@ test_that("get_error returns error data for civis_error", {
 test_that("verbose produces correct messages", {
   f <- function(x) {
     x <- runif(1)
-    if (x > .5) return(list(state = "running", x=NULL)) else return(list(state = "success", x=x))
+    if (x > .5) {
+      return(list(state = "running", x = NULL))
+    } else {
+      return(list(state = "success", x = x))
+    }
   }
   set.seed(4)
   msg <- capture_messages(await(f, x = 1, .status_key = "state",
-                                .success_states = c("success", "fail"), 
+                                .success_states = c("success", "fail"),
              .verbose = TRUE))
   patterns <- c("Status: running", "Retry 1 in 0.302 seconds")
   expect_true(all(stringr::str_detect(msg, patterns)))
-  
+
   set.seed(4)
-  msg <- capture_messages(await(f, x = 1, .status_key = "state", 
-                                .success_states = c("success", "fail"), 
+  msg <- capture_messages(await(f, x = 1, .status_key = "state",
+                                .success_states = c("success", "fail"),
                                 .verbose = TRUE, .interval = .01))
   patterns <- c("Status: running", "Retry 1 in 0.01 seconds")
   expect_true(all(stringr::str_detect(msg, patterns)))
@@ -120,7 +128,7 @@ test_that("verbose produces correct messages", {
 test_that("call_once returns list with element called", {
   f <- function(id) return(list(state = "succeeded"))
   expect_true(call_once(f, .id = 1)$called)
-  
+
   f <- function(id) return(list(state = "partying instead"))
   expect_false(call_once(f, .id = 1)$called)
 })
@@ -132,7 +140,7 @@ test_that("if called, get_status(r$response) returns status", {
 
 test_that("call_once captures completed_states and status_keys", {
   f <- function(id) return(list(party_status = "at the party"))
-  expect_true(call_once(f, .id = 1, .success_states = "at the party", 
+  expect_true(call_once(f, .id = 1, .success_states = "at the party",
                         .status_key = "party_status")$called)
 })
 
@@ -142,7 +150,7 @@ test_that("safe_call_once catches civis_await_error", {
   expect_true(r$called)
   expect_equal(r$response$x, 1)
   expect_equal(get_status(r$response), "succeeded")
-  
+
   f <- function(x) list(state = "failed", error = "platform error")
   e <- safe_call_once(f, x = 1)
   expect_is(e, c("civis_await_error", "civis_error", "error"))
@@ -174,41 +182,41 @@ test_that("await_all returns list of completed responses", {
   expect_equal(sapply(x, function(x) x$job_id), rep(1, 2))
 })
 
-test_that("await_all vectorizes over any argument", {  
+test_that("await_all vectorizes over any argument", {
   x <- await_all(f_rand, .x = 1:2, id = 1)
   expect_equal(sapply(x, function(x) x$job_id), 1:2)
 })
-  
+
 test_that("await_all catches arbitrary status and keys", {
   f <- function(x) list(party_status = "going home", value = x)
-  x <- await_all(f, .x = 1:2,  .status_key = "party_status", 
+  x <- await_all(f, .x = 1:2,  .status_key = "party_status",
                  .success_states = "going home", .verbose = TRUE)
   expect_equal(sapply(x, get_status), rep("going home", 2))
   expect_equal(sapply(x, function(x) x$value), 1:2)
 })
-  
+
 test_that("await_all throws civis_timeout_error", {
-  f <- function(x) list(state = "at the party") 
+  f <- function(x) list(state = "at the party")
   msg <- c("Timeout exceeded. Current status: at the party, at the party")
-  expect_error(await_all(f, .x=1:2, .timeout = .002, .interval = .001), msg)
-  
-  e <- tryCatch(await_all(f, .x=1:2, .timeout = .002, .interval = .001), 
+  expect_error(await_all(f, .x = 1:2, .timeout = .002, .interval = .001), msg)
+
+  e <- tryCatch(await_all(f, .x = 1:2, .timeout = .002, .interval = .001),
            "civis_timeout_error" = function(e) e)
-  
+
   get_error(e)
-  
-  e2 <- tryCatch(await_all(f, .x=1:2, .timeout = .002, .interval = .001), 
+
+  e2 <- tryCatch(await_all(f, .x = 1:2, .timeout = .002, .interval = .001),
                 "civis_error" = function(e) e)
   expect_equal(e, e2)
 })
 
 test_that("await_all catches mixed failure states", {
-  f <- function(x) { 
+  f <- function(x) {
     switch(x, list(state = "succeeded"),
            list(state = "failed", error = "platform error"),
            list(state = "succeeded"))
   }
-  r <- await_all(f, .x=1:3)
+  r <- await_all(f, .x = 1:3)
   expect_true(is.civis_error(r[[2]]))
   expect_equal(get_error(r[[2]])$error, "platform error")
   expect_equal(get_error(r[[2]])$args, list(x = 2))

--- a/tests/testthat/test_civis_ml.R
+++ b/tests/testthat/test_civis_ml.R
@@ -1,4 +1,5 @@
 library(mockery)
+context("civis_ml")
 
 test_that("jsonlite works", {
   # The tests below fail when run via R CMD check due with a
@@ -11,7 +12,6 @@ test_that("jsonlite works", {
 
 ################################################################################
 # Build
-context("civis_ml")
 
 test_that("calls scripts_post_custom", {
   fake_get_database_id <- mock(456, cycle = TRUE)

--- a/tests/testthat/test_civis_ml_utils.R
+++ b/tests/testthat/test_civis_ml_utils.R
@@ -12,7 +12,7 @@ reg_algo <- paste0(c("sparse_linear", "sparse_ridge", "gradient_boosting",
 
 str_detect_multiple <- function(string, pattern){
   mapply(function(string, pattern) stringr::str_detect(string, pattern),
-         string=string, pattern=pattern)
+         string = string, pattern = pattern)
 }
 
 

--- a/tests/testthat/test_client_base.R
+++ b/tests/testthat/test_client_base.R
@@ -1,5 +1,5 @@
 library(civis)
-context("Client Base")
+context("client base")
 
 ###############################################################################
 # Set up
@@ -45,11 +45,11 @@ test_that("print and str methods for civis_api", {
     `httr::VERB` = function(...) httr_200,
     `httr::RETRY` = function(...) httr_200,
     call_api("GET", path, path_params, query_params, body_params))
-  
+
   # print hides attributes
   expect_false(stringr::str_detect(capture_output(print(response)), "attribute"))
-  
-  # str shows attributes and structure 
+
+  # str shows attributes and structure
   resp_str <- capture_output(str(response, 1))
   expect_true(stringr::str_detect(resp_str, "attr"))
   expect_true(stringr::str_detect(resp_str, "List of 8"))
@@ -86,7 +86,7 @@ test_that("stop_for_status concatenates Platform specific errors", {
   error <- "Gateway Timeout \\(HTTP 504\\). hi from platform!"
   with_mock(
     # Mocks the response so it includes an error like those in Platform
-    `httr::content` = function(...) list(errorDescription="hi from platform!"),
+    `httr::content` = function(...) list(errorDescription = "hi from platform!"),
     expect_error(stop_for_status(httr_504), error)
   )
 })
@@ -98,14 +98,14 @@ test_that("204, 205 responses return NULL", {
       call_api("POST", path, path_params, query_params, body_params))
   expect_null(response$content)
   expect_is(response, "civis_api")
-  
+
   response <- with_mock(
       `civis::api_key` = function(...) "fake_key",
       `httr::RETRY` = function(...) httr_205,
       call_api("GET", path, path_params, query_params, body_params))
   expect_null(response$content)
   expect_is(response, "civis_api")
-  
+
 })
 
 test_that("failing to parse JSON content returns CivisClientError", {
@@ -114,16 +114,16 @@ test_that("failing to parse JSON content returns CivisClientError", {
     `civis::api_key` = function(...) "fake_key",
     `httr::VERB` = function(...) httr_200,
     `httr::RETRY` = function(...) httr_200,
-    
+
     # This simulates httr::content failing with an arbitrary error/message
     `httr::content` = function(...) stop("httr failed to parse response, throwing an error!"),
-    
+
     # Tests for the right error message (same as python client)
     expect_error(call_api("GET", path, path_params, query_params, body_params), error),
-    
+
     # Tests that the error is a CivisClientError (same as python client) that is try-catchable
     expect_true(
-      tryCatch(call_api("GET", path, path_params, query_params, body_params), 
+      tryCatch(call_api("GET", path, path_params, query_params, body_params),
              civis_api_error = function(c) TRUE,
              error = function(e) FALSE)
     ))

--- a/tests/testthat/test_fill_text_template.R
+++ b/tests/testthat/test_fill_text_template.R
@@ -1,5 +1,5 @@
 library(civis)
-context("URL template format")
+context("fill_text_template")
 
 test_that("fill_text_template returns the same string with no subs", {
   url <- "/scripts"

--- a/tests/testthat/test_io.R
+++ b/tests/testthat/test_io.R
@@ -1,5 +1,5 @@
 library(civis)
-context("IO functions")
+context("io")
 
 # read_civis ------------------------------------------------------------------
 
@@ -9,7 +9,7 @@ test_that("read_civis returns a dataframe or error appropriately", {
   mock_df <- read.csv(con)
   close(con)
   rm(con)
-  mock_sql_job <- function(...) list(script_id=1337, run_id=007)
+  mock_sql_job <- function(...) list(script_id = 1337, run_id = 007)
 
   mock_GET_result <- function(...) {
 
@@ -24,22 +24,23 @@ test_that("read_civis returns a dataframe or error appropriately", {
     `civis::scripts_get_sql_runs` = function(...) list(state = "succeeded"),
     `civis::download_script_results` = mock_GET_result,
     `civis::stop_for_status` = function(...) return(TRUE),
-    `civis::scripts_post_sql_runs` = function(...) list(id=1001),
+    `civis::scripts_post_sql_runs` = function(...) list(id = 1001),
     `civis::files_get` = function(...) list(url = "whatever"),
     `httr::GET` = mock_GET_result,
-    expect_equal(mock_df, read_civis(x="lazy", database="jellyfish")),
-    expect_equal(mock_df, read_civis(dplyr::sql("SELECT * FROM lazy"), database = "jellyfish")),
+    expect_equal(mock_df, read_civis(x = "lazy", database = "jellyfish")),
+    expect_equal(mock_df, read_civis(dplyr::sql("SELECT * FROM lazy"),
+                                     database = "jellyfish")),
     expect_equal(mock_df, read_civis(123, using = read.csv))
   )
 })
 
 test_that("read_civis produces catchable error when query returns no rows", {
-  no_results_resp <- list(state="succeeded", output = list())
-  mock_sql_job <- function(...) list(script_id=561, run_id=43)
+  no_results_resp <- list(state = "succeeded", output = list())
+  mock_sql_job <- function(...) list(script_id = 561, run_id = 43)
   with_mock(
     `civis::start_scripted_sql_job` = mock_sql_job,
     `civis::scripts_get_sql_runs` = function(...) no_results_resp,
-    try_err <- try(read_civis(dplyr::sql("SELECT 0"), database="arrgh")),
+    try_err <- try(read_civis(dplyr::sql("SELECT 0"), database = "arrgh"), silent = TRUE),
     expect_true("empty_result_error" %in% class(attr(try_err, "condition")))
   )
 })
@@ -47,14 +48,14 @@ test_that("read_civis produces catchable error when query returns no rows", {
 # write_civis -----------------------------------------------------------------
 
 test_that("write_civis.character returns meta data if successful", {
-  mock_df <- cbind.data.frame(a=c(1,2), b=c("cape-cod", "clams"))
+  mock_df <- cbind.data.frame(a = c(1,2), b = c("cape-cod", "clams"))
   write("", file = "mockfile")
   res <- with_mock(
     `civis::start_import_job` = function(...) {
-      list(uploadUri="fake", id = 1)
+      list(uploadUri = "fake", id = 1)
     },
     `civis::tables_post_refresh` = function(id) "",
-    `httr::PUT` = function(...) list(status_code=200),
+    `httr::PUT` = function(...) list(status_code = 200),
     `civis::imports_post_files_runs` = function(...) list(""),
     `civis::imports_get_files_runs` = function(...) list(state = "succeeded"),
       write_civis("mockfile", "mock.table", "mockdb")
@@ -64,12 +65,12 @@ test_that("write_civis.character returns meta data if successful", {
 })
 
 test_that("write_civis.character fails if file doesn't exist", {
-  mock_df <- cbind.data.frame(a=c(1,2), b=c("cape-cod", "clams"))
+  mock_df <- cbind.data.frame(a = c(1,2), b = c("cape-cod", "clams"))
   err_msg <- with_mock(
     `civis::start_import_job` = function(...) {
-      list(uploadUri="fake")
+      list(uploadUri = "fake")
     },
-    `httr::PUT` = function(...) list(status_code=200),
+    `httr::PUT` = function(...) list(status_code = 200),
     `civis::imports_post_files_runs` = function(...) list(""),
     `civis::imports_get_files_runs` = function(...) list(state = "succeeded"),
     tryCatch(write_civis("mockfile", "mock.table", "mockdb"), error = function(e) e$message)
@@ -79,13 +80,13 @@ test_that("write_civis.character fails if file doesn't exist", {
 })
 
 test_that("write_civis.data.frame returns meta data if successful", {
-  mock_df <- cbind.data.frame(a=c(1,2), b=c("cape-cod", "clams"))
+  mock_df <- cbind.data.frame(a = c(1,2), b = c("cape-cod", "clams"))
   res <- with_mock(
     `civis::start_import_job` = function(...) {
-      list(uploadUri="fake", id = 1)
+      list(uploadUri = "fake", id = 1)
     },
     `civis::tables_post_refresh` = function(id) "",
-    `httr::PUT` = function(...) list(status_code=200),
+    `httr::PUT` = function(...) list(status_code = 200),
     `civis::imports_post_files_runs` = function(...) list(""),
     `civis::imports_get_files_runs` = function(...) list(state = "succeeded"),
     `civis::tables_list` = function(...) 1,
@@ -95,12 +96,12 @@ test_that("write_civis.data.frame returns meta data if successful", {
 })
 
 test_that("write_civis.character warns under failure", {
-  mock_df <- cbind.data.frame(a=c(1,2), b=c("cape-cod", "clams"))
+  mock_df <- cbind.data.frame(a = c(1,2), b = c("cape-cod", "clams"))
   with_mock(
     `civis::start_import_job` = function(...) {
-      list(uploadUri="fake", id=-999)
+      list(uploadUri = "fake", id = -999)
     },
-    `httr::PUT` = function(...) list(status_code=200),
+    `httr::PUT` = function(...) list(status_code = 200),
     `civis::imports_post_files_runs` = function(...) "",
     `civis::imports_get_files_runs` = function(...) list(state = "failed"),
     `httr::content` = function(...) "error",
@@ -134,7 +135,7 @@ test_that("write_civis_file.character returns a file id", {
 })
 
 test_that("write_civis_file.default returns a file id", {
-  mock_df <- data.frame(a=c(1,2), b=c("cape-cod", "clams"))
+  mock_df <- data.frame(a = c(1,2), b = c("cape-cod", "clams"))
   with_mock(
     `civis::files_post` = function(...) list(uploadFields = list("fakeurl.com"), id = 5),
     `httr::upload_file` = function(...) "the file",
@@ -166,8 +167,8 @@ test_that("query_civis returns object from await", {
   with_mock(
     `civis::get_database_id` = function(...) TRUE,
     `civis::default_credential` = function(...) TRUE,
-    `civis::queries_post` = function(...) list(id="query_id"),
-    `civis::queries_get` = function(...) list(state='succeeded'),
+    `civis::queries_post` = function(...) list(id = "query_id"),
+    `civis::queries_get` = function(...) list(state = 'succeeded'),
     expect_equal(get_status(query_civis("query", "database")), 'succeeded')
   )
 })
@@ -220,15 +221,15 @@ test_that("start_import_job parses table correctly", {
     `civis::default_credential` = function(...) "fake",
     `civis::imports_post_files` = function(...) {
       args <- list(...)
-      list(schema=args[[1]], table=args[[2]])
+      list(schema = args[[1]], table = args[[2]])
     },
     expect_equal(
-      start_import_job("mockdb", "mock.table", if_exists="append",
+      start_import_job("mockdb", "mock.table", if_exists = "append",
                        NULL, NULL, NULL, NULL),
-      list(schema="mock", table="table")
+      list(schema = "mock", table = "table")
     ),
     expect_error(
-      start_import_job("mockdb", "mock.table", if_exists="error",
+      start_import_job("mockdb", "mock.table", if_exists = "error",
                        NULL, NULL, NULL, NULL),
       error_msg
     )

--- a/tests/testthat/test_pagination.R
+++ b/tests/testthat/test_pagination.R
@@ -1,5 +1,5 @@
 library(civis)
-context("Pagination Helpers")
+context("pagination")
 
 test_that("calls fn the proper number of times", {
   n_calls <- 0

--- a/tests/testthat/test_reports.R
+++ b/tests/testthat/test_reports.R
@@ -1,12 +1,13 @@
 library(civis)
-context("Report functions")
+library(mockery)
+context("reports")
 
 test_that("rmd_file overwritting warning is called", {
   warn_msg <- "parameter 'input' is ignored. Using 'rmd_file' instead."
   with_mock(
     `rmarkdown::render` = function(...) TRUE,
     `civis::publish_html` = function(...) -999,
-    expect_warning(publish_rmd("fake.Rmd", input="duplicate"), warn_msg)
+    expect_warning(publish_rmd("fake.Rmd", input = "duplicate"), warn_msg)
   )
 })
 
@@ -16,7 +17,7 @@ test_that("output_file overrides temp file when passed.", {
   with_mock(
     `civis::publish_html` = mock_publish_html,
     `rmarkdown::render` = function(...) TRUE,
-    publish_rmd("fake.Rmd", output_file=output_file)
+    publish_rmd("fake.Rmd", output_file = output_file)
   )
   publish_html_args <- mockery::mock_args(mock_publish_html)[[1]]
   expect_equal(publish_html_args[[1]], output_file)
@@ -26,29 +27,26 @@ test_that("publish_rmd passes project_id", {
   with_mock(
     `civis::publish_html` = function(project_id, ...) cat(project_id),
     `rmarkdown::render` = function(...) TRUE,
-    expect_output(publish_rmd("rmd", project_id="abc123"), "abc123"),
+    expect_output(publish_rmd("rmd", project_id = "abc123"), "abc123"),
     expect_output(publish_rmd("rmd"), NA)
   )
 })
 
 test_that("publish_html calls reports_put_project", {
-  reports_put_project_call <- list()
+  mock_reports_put_projects <- mockery::mock(reports_put_projects)
   with_mock(
     `readChar` = function(...) TRUE,
-    `civis::reports_post` = function(...) list(id="fake_report"),
-    `civis::reports_put_projects` = function(id, project_id) {
-      reports_put_project_call <<- list(id = id, project_id = project_id)
-    },
-    publish_html("fake.html", project_id = "project_1"),
-    expect_equal(reports_put_project_call$id, "fake_report"),
-    expect_equal(reports_put_project_call$project_id, "project_1")
+    `civis::reports_post` = function(...) list(id = "fake_report"),
+    `civis::reports_put_projects` = mock_reports_put_projects,
+    publish_html("fake.html", project_id = "project_1")
   )
+  expect_args(mock_reports_put_projects, 1, id = "fake_report", project_id = "project_1")
 })
 
 test_that("publish_html does not call reports_put_projects", {
   with_mock(
     `readChar` = function(...) TRUE,
-    `civis::reports_post` = function(...) list(id="fake_report"),
+    `civis::reports_post` = function(...) list(id = "fake_report"),
     `civis::reports_put_projects` = function(id, project_id) stop("should not be called"),
     expect_silent(publish_html("fake.html"))
   )
@@ -57,9 +55,9 @@ test_that("publish_html does not call reports_put_projects", {
 test_that("publish_html can put an existing report", {
   with_mock(
     `readChar` = function(...) TRUE,
-    `civis::reports_patch` = function(report_id, ...) list(id=report_id),
+    `civis::reports_patch` = function(report_id, ...) list(id = report_id),
     `civis::reports_post` = function(...) stop("should not be called"),
-    expect_equal(publish_html("fake_html", report_id=123), 123)
+    expect_equal(publish_html("fake_html", report_id = 123), 123)
   )
 })
 

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -1,5 +1,5 @@
 library(civis)
-context("Util functions")
+context("utils")
 
 
 db_list_response <- list(

--- a/tests/testthat/utils.R
+++ b/tests/testthat/utils.R
@@ -1,3 +1,5 @@
+library(mockery)
+
 check_civis_ml_call <- function(workflow_fn, can_calibrate = TRUE) {
   fake_civis_ml <- mock(NULL)
 

--- a/tools/generate_civis_ml_test_data.R
+++ b/tools/generate_civis_ml_test_data.R
@@ -1,11 +1,13 @@
 library(civis)
 library(future)
 
-cat("setting up models...", fill =T)
+cat("setting up models...", fill = TRUE)
 plan("multisession", workers = 20)
 
-class_algo <- c("sparse_logistic", "gradient_boosting_classifier", "random_forest_classifier", "extra_trees_classifier")
-reg_algo <- paste0(c("sparse_linear", "sparse_ridge", "gradient_boosting", "random_forest", "extra_trees"), "_regressor")
+class_algo <- c("sparse_logistic", "gradient_boosting_classifier",
+                "random_forest_classifier", "extra_trees_classifier")
+reg_algo <- paste0(c("sparse_linear", "sparse_ridge", "gradient_boosting",
+                     "random_forest", "extra_trees"), "_regressor")
 
 do_class <- function(algo) {
   future(civis_ml(civis_table("datascience.iris", "redshift-general"),

--- a/tools/generate_default_client.R
+++ b/tools/generate_default_client.R
@@ -7,14 +7,14 @@ source("../R/utils.R")
 api_spec <- get_spec()
 base_regex <- paste0("^/", BASE_RESOURCES_V1)
 
-path_idx <- unlist(lapply(base_regex, function(regex, nam){ 
+path_idx <- unlist(lapply(base_regex, function(regex, nam){
     grep(regex, nam)
-  }, nam=names(api_spec$paths)))
+  }, nam = names(api_spec$paths)))
 
 api_spec$paths <- api_spec$paths[unique(path_idx)]
 
 # To pass R CMD CHECK, this has to be an 'R Data file' (rda) produced by save.
 save(api_spec, file = "../R/sysdata.rda")
-client_str <- generate_client(api_spec, IGNORE=IGNORE)
-write_client(client_str, FILENAME=paste0("../", FILENAME))
+client_str <- generate_client(api_spec, IGNORE = IGNORE)
+write_client(client_str, FILENAME = paste0("../", FILENAME))
 devtools::document()

--- a/tools/integration_tests/smoke_test.R
+++ b/tools/integration_tests/smoke_test.R
@@ -120,13 +120,13 @@ test_that("Reports are created", {
     {
       rmd <- c("```{r}", "summary(cars)", "```")
       html <- "<div><ul>A</ul><ul>B</ul><ul>C</ul></div>"
-      rmd_file <- tempfile(fileext=".Rmd")
+      rmd_file <- tempfile(fileext = ".Rmd")
       md_file <- gsub(".Rmd", ".md", basename(rmd_file))
-      html_file <- tempfile(fileext=".html")
+      html_file <- tempfile(fileext = ".html")
       write(rmd, rmd_file)
       write(html, html_file)
-      out1 <- publish_rmd(rmd_file=rmd_file, report_name="R Smoke Test")
-      out2 <- publish_html(html_file, report_name="R Smoke Test2")
+      out1 <- publish_rmd(rmd_file = rmd_file, report_name = "R Smoke Test")
+      out2 <- publish_html(html_file, report_name = "R Smoke Test2")
       expect_true(is.numeric(out1))
       expect_true(is.numeric(out2))
     }, finally = {
@@ -155,4 +155,4 @@ test_that("iris model works", {
 end <- proc.time()
 tot <- end - start
 
-cat("total time: ", tot[3], "s", fill=TRUE)
+cat("total time: ", tot[3], "s", fill = TRUE)

--- a/tools/run_generate_client.R
+++ b/tools/run_generate_client.R
@@ -5,11 +5,11 @@ source("R/utils.R")
 if (Sys.getenv("R_CLIENT_DEV") != "TRUE") {
   message("Generating API")
   spec <- get_spec()
-  client_str <- generate_client(spec, IGNORE=IGNORE)
-  
+  client_str <- generate_client(spec, IGNORE = IGNORE)
+
   message(paste0("Writing API to ", FILENAME))
-  write_client(client_str, FILENAME=FILENAME)
-  
+  write_client(client_str, FILENAME = FILENAME)
+
   devtools::document()
 } else {
   message("Skipping client generation")


### PR DESCRIPTION
Some cleanup! Inspired because the new Rstudio 1.1.1 has a reasonable linter (cmd-option-shift-D).

I also found a small bug in `write_civis.character`.

@keithing or @wlattner this is probably a good PR to suggest other minor irritations that I can fix.

- `write_civis.character` now correctly reads default database.
- `test_reports publish_html` refactored to use mock
- tests now have all lower case names in `context`
- better respect of the 80 character 
