### PR TITLE
[RCL-165] Add drop as option for if_exists in write_civis

### DIFF
--- a/R/io.R
+++ b/R/io.R
@@ -578,8 +578,8 @@ start_scripted_sql_job <- function(database, sql, job_name, hidden = TRUE,
 # Kick off a job to send data to the civis platform
 start_import_job <- function(database, tablename, if_exists, distkey,
                              sortkey1, sortkey2, max_errors) {
-  if (!if_exists %in% c("fail", "truncate", "append")) {
-    stop('if_exists must be set to "fail", "truncate" or "append"')
+  if (!if_exists %in% c("fail", "truncate", "append", "drop")) {
+    stop('if_exists must be set to "fail", "truncate", "append", or "drop"')
   }
 
   # Split tablename into schema and table

--- a/tests/testthat/test_io.R
+++ b/tests/testthat/test_io.R
@@ -215,7 +215,6 @@ test_that("delimiter_name_from_string catches bad input", {
 })
 
 test_that("start_import_job parses table correctly", {
-  error_msg <- 'if_exists must be set to "fail", "truncate" or "append"'
   with_mock(
     `civis::get_database_id` = function(...) -999,
     `civis::default_credential` = function(...) "fake",
@@ -227,15 +226,26 @@ test_that("start_import_job parses table correctly", {
       start_import_job("mockdb", "mock.table", if_exists = "append",
                        NULL, NULL, NULL, NULL),
       list(schema = "mock", table = "table")
-    ),
+    )
+  )
+})
+
+test_that("start_import_job checks if_exists value", {
+  error_msg <- 'if_exists must be set to "fail", "truncate", "append", or "drop"'
+  with_mock(
+    `civis::get_database_id` = function(...) -999,
+    `civis::default_credential` = function(...) "fake",
+    `civis::imports_post_files` = function(...) {
+      args <- list(...)
+      list(schema=args[[1]], table=args[[2]])
+    },
     expect_error(
-      start_import_job("mockdb", "mock.table", if_exists = "error",
+      start_import_job("mockdb", "mock.table", if_exists="do nothing",
                        NULL, NULL, NULL, NULL),
       error_msg
     )
   )
 })
-
 
 test_that("download_script_results returns sensible errors", {
   error <- "Query produced no output. \\(script_id = 561, run_id = 43\\)"


### PR DESCRIPTION
We were incorrectly raising an error for `if_exists = "drop"` in `write_civis`, according to the api docs, we can pass "fail", "truncate", "append", or "drop".

@patr1ckm or @keithing for review.