### PR TITLE
[RCL-66] FIX: Change LICENSE format, revise description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,10 +9,8 @@ Authors@R: c(
   person("Michelangelo", "D'Agostino", email = "mdagostino@civisanalytics.com", role = "ctb"),
   person("Sam", "Weiss", email = "sweiss@civisanalytics.com", role = "ctb"),
   person("Danning", "Chen", email = "dchen@civisanalytics.com", role = "ctb"))
-Description: The Civis API R client is an R package that helps analysts and
-  developers interact with the Civis Platform. The package includes a set of
-  tools around common workflows as well as a convenient interface to make
-  requests directly to the Civis API.
+Description: The package includes a set of tools around common workflows and a convenient interface to make
+  requests directly to the Civis Data Science API (https://www.civisanalytics.com/platform/).
 Depends:
     R (>= 3.2.0)
 License: BSD_3_clause + file LICENSE

--- a/LICENSE
+++ b/LICENSE
@@ -1,27 +1,3 @@
-Copyright (c) 2017, Civis Analytics
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors
-   may be used to endorse or promote products derived from this software
-   without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+YEAR: 2017
+COPYRIGHT HOLDER: Civis Analytics
+ORGANIZATION: Civis Analytics


### PR DESCRIPTION
This fixes the following requests from CRAN maintainer:

```
Thanks, please omit the redundant "is an R package that helps analysts and developers" part. Rather add a webb reference in the form <http......> to the API.

License: BSD_3_clause + file LICENSE

We see:

License components with restrictions and base license permitting such:
  BSD_3_clause + file LICENSE
File 'LICENSE':
  Copyright (c) 2017, Civis Analytics
  All rights reserved.
...

Please only use the CRAN template for the BSD_3_clause license as file LICENSE.

Please fix and resubmit.
```
[Here](https://cran.r-project.org/web/packages/splusTimeSeries/index.html) is an example of how `LICENSE` will work with the `BSD_3_clause` template.