### PR TITLE
[RCL-174] fix build issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.0.1] - 2017-09-18
+
+### Fixed
+
+- `configure` and `configure.win` now use `R_HOME` to find `Rscript` instead of assuming that `Rscript` is on the path.
+- `configure` uses `bin/sh` instead of `bin/bash`
+- `configure.win` uses `Rscript.exe` for windows builds
+- `configure.win` does not use `bin/bash`.
+
 ## [1.0.0] - 2017-09-08
 
 ### Added 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: civis
 Title: R Client for the 'Civis data science API'
-Version: 1.0.0
+Version: 1.0.1
 Authors@R: c(
   person("Patrick", "Miller", email = "pmiller@civisanalytics.com", role = c("cre", "aut")),
   person("Keith", "Ingersoll", email = "kingersoll@civisanalytics.com", role = "aut"),
@@ -20,8 +20,6 @@ BugReports: https://github.com/civisanalytics/civis-r/issues
 Imports:
     httr,
     jsonlite,
-    lazyeval,
-    assertthat,
     purrr,
     methods,
     stats,

--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
-Rscript tools/run_generate_client.R
+"${R_HOME}"/bin/Rscript tools/run_generate_client.R
 

--- a/configure.win
+++ b/configure.win
@@ -1,4 +1,2 @@
-#!/bin/bash
-
-Rscript tools/run_generate_client.R
+"${R_HOME}"/bin${R_ARCH_BIN}/Rscript.exe tools/run_generate_client.R
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,14 @@
+This submission fixes build issues:
+
+- `configure` and `configure.win` now use `R_HOME` to find `Rscript` instead of assuming that `Rscript` is on the path.
+- `configure.win` uses `Rscript.exe` for windows builds.
+- `configure` uses `bin/sh` instead of `bin/bash`
+- `configure.win` does not use `bin/bash`.
+
+Unfortunately, we are unable to test the actual build environments, so we have to make repeated submissions until this works. Thank you for your patience.
+
+The version has been bumped to 1.0.1.
+
 ## Test environments
 * local OS X install, R 3.4.1
 * ubuntu 12.04 (on travis-ci), R 3.4.1


### PR DESCRIPTION
I think this will fix the [build issues](https://cran.r-project.org/web/checks/check_results_civis.html) on CRAN. 

On unix platforms, we use `bin/sh` instead of `bin/bash` as per [this footnote](https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#FOOT24). `Rscript` is located through the use of the `R_HOME` environment variable temporarily created in `R CMD INSTALL`, as per the examples in the [configure docs](https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Configure-and-cleanup). 

Windows uses uses the `ash` shell. Like in unix alikes, we use locate `R_HOME` to find `Rscript.exe` (also documented [here](https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Configure-and-cleanup)).

I'm still working on replicating the environments these were created in. 

@keithing 