### PR TITLE
ENH add new parameters to civis_ml training and prediction

### DIFF
--- a/R/civis_ml.R
+++ b/R/civis_ml.R
@@ -68,10 +68,10 @@
 #' @param notifications Optional, model status notifications. See
 #'   \code{\link{scripts_post_custom}} for further documentation about email
 #'   and URL notification.
+#' @param polling_interval Check for job completion every this number of seconds.
 #' @param validation_data Optional, source for validation data. There are
 #'   currently two options: \code{train} (the default), which uses training
 #'   data for validation, and \code{skip}, which skips the validation step.
-#' @param polling_interval Check for job completion every this number of seconds.
 #' @param verbose Optional, If \code{TRUE}, supply debug outputs in Platform
 #'   logs and make prediction child jobs visible.
 #' @param \dots Unused
@@ -309,9 +309,9 @@ civis_ml.civis_table <- function(x,
                                  memory_requested = NULL,
                                  disk_requested = NULL,
                                  notifications = NULL,
+                                 polling_interval = NULL,
                                  validation_data = c('train', 'skip'),
                                  n_jobs = NULL,
-                                 polling_interval = NULL,
                                  verbose = FALSE) {
 
   oos_scores_if_exists <- match.arg(oos_scores_if_exists)
@@ -365,9 +365,9 @@ civis_ml.civis_file <- function(x,
                                 memory_requested = NULL,
                                 disk_requested = NULL,
                                 notifications = NULL,
+                                polling_interval = NULL,
                                 validation_data = c('train', 'skip'),
                                 n_jobs = NULL,
-                                polling_interval = NULL,
                                 verbose = FALSE) {
 
   oos_scores_if_exists <- match.arg(oos_scores_if_exists)
@@ -418,9 +418,9 @@ civis_ml.character <- function(x,
                                memory_requested = NULL,
                                disk_requested = NULL,
                                notifications = NULL,
+                               polling_interval = NULL,
                                validation_data = c('train', 'skip'),
                                n_jobs = NULL,
-                               polling_interval = NULL,
                                verbose = FALSE) {
 
   oos_scores_if_exists <- match.arg(oos_scores_if_exists)

--- a/man/civis_ml.Rd
+++ b/man/civis_ml.Rd
@@ -14,13 +14,14 @@ civis_ml(x, dependent_variable, model_type, primary_key = NULL,
   oos_scores_if_exists = c("fail", "append", "drop", "truncate"),
   model_name = NULL, cpu_requested = NULL, memory_requested = NULL,
   disk_requested = NULL, notifications = NULL, polling_interval = NULL,
-  verbose = FALSE)
+  validation_data = c("train", "skip"), n_jobs = NULL, verbose = FALSE)
 
 civis_ml_fetch_existing(model_id, run_id = NULL)
 
 \method{predict}{civis_ml}(object, newdata, primary_key = NA,
   output_table = NULL, output_db = NULL, if_output_exists = c("fail",
-  "append", "drop", "truncate"), n_jobs = NULL, polling_interval = NULL,
+  "append", "drop", "truncate"), n_jobs = NULL, cpu_requested = NULL,
+  memory_requested = NULL, disk_requested = NULL, polling_interval = NULL,
   verbose = FALSE, ...)
 }
 \arguments{
@@ -73,19 +74,27 @@ The default is \code{"fail"}.}
 It will have \code{" Train"} or \code{" Predict"} added to become the Script title.}
 
 \item{cpu_requested}{Optional, the number of CPU shares requested in the
-Civis Platform for training jobs. 1024 shares = 1 CPU.}
+Civis Platform for training jobs or prediction child jobs.
+1024 shares = 1 CPU.}
 
 \item{memory_requested}{Optional, the memory requested from Civis Platform
-for training jobs, in MiB.}
+for training jobs or prediction child jobs, in MiB.}
 
 \item{disk_requested}{Optional, the disk space requested on Civis Platform
-for training jobs, in GB.}
+for training jobs or prediction child jobs, in GB.}
 
 \item{notifications}{Optional, model status notifications. See
 \code{\link{scripts_post_custom}} for further documentation about email
 and URL notification.}
 
 \item{polling_interval}{Check for job completion every this number of seconds.}
+
+\item{validation_data}{Optional, source for validation data. There are
+currently two options: \code{train} (the default), which uses training
+data for validation, and \code{skip}, which skips the validation step.}
+
+\item{n_jobs}{Number of concurrent Platform jobs to use for training and
+validation, or multi-file / large table prediction.}
 
 \item{verbose}{Optional, If \code{TRUE}, supply debug outputs in Platform
 logs and make prediction child jobs visible.}
@@ -105,9 +114,6 @@ the model was built.}
 
 \item{if_output_exists}{Action to take if the prediction table already exists. One of \code{"fail"}, \code{"append"}, \code{"drop"}, or \code{"truncate"}.
 The default is \code{"fail"}.}
-
-\item{n_jobs}{Number of concurrent Platform jobs to use for
-multi-file / large table prediction.}
 
 \item{\dots}{Unused}
 }

--- a/man/civis_ml_extra_trees_classifier.Rd
+++ b/man/civis_ml_extra_trees_classifier.Rd
@@ -121,13 +121,14 @@ The default is \code{"fail"}.}
 It will have \code{" Train"} or \code{" Predict"} added to become the Script title.}
 
 \item{cpu_requested}{Optional, the number of CPU shares requested in the
-Civis Platform for training jobs. 1024 shares = 1 CPU.}
+Civis Platform for training jobs or prediction child jobs.
+1024 shares = 1 CPU.}
 
 \item{memory_requested}{Optional, the memory requested from Civis Platform
-for training jobs, in MiB.}
+for training jobs or prediction child jobs, in MiB.}
 
 \item{disk_requested}{Optional, the disk space requested on Civis Platform
-for training jobs, in GB.}
+for training jobs or prediction child jobs, in GB.}
 
 \item{notifications}{Optional, model status notifications. See
 \code{\link{scripts_post_custom}} for further documentation about email

--- a/man/civis_ml_extra_trees_regressor.Rd
+++ b/man/civis_ml_extra_trees_regressor.Rd
@@ -106,13 +106,14 @@ The default is \code{"fail"}.}
 It will have \code{" Train"} or \code{" Predict"} added to become the Script title.}
 
 \item{cpu_requested}{Optional, the number of CPU shares requested in the
-Civis Platform for training jobs. 1024 shares = 1 CPU.}
+Civis Platform for training jobs or prediction child jobs.
+1024 shares = 1 CPU.}
 
 \item{memory_requested}{Optional, the memory requested from Civis Platform
-for training jobs, in MiB.}
+for training jobs or prediction child jobs, in MiB.}
 
 \item{disk_requested}{Optional, the disk space requested on Civis Platform
-for training jobs, in GB.}
+for training jobs or prediction child jobs, in GB.}
 
 \item{notifications}{Optional, model status notifications. See
 \code{\link{scripts_post_custom}} for further documentation about email

--- a/man/civis_ml_gradient_boosting_classifier.Rd
+++ b/man/civis_ml_gradient_boosting_classifier.Rd
@@ -128,13 +128,14 @@ The default is \code{"fail"}.}
 It will have \code{" Train"} or \code{" Predict"} added to become the Script title.}
 
 \item{cpu_requested}{Optional, the number of CPU shares requested in the
-Civis Platform for training jobs. 1024 shares = 1 CPU.}
+Civis Platform for training jobs or prediction child jobs.
+1024 shares = 1 CPU.}
 
 \item{memory_requested}{Optional, the memory requested from Civis Platform
-for training jobs, in MiB.}
+for training jobs or prediction child jobs, in MiB.}
 
 \item{disk_requested}{Optional, the disk space requested on Civis Platform
-for training jobs, in GB.}
+for training jobs or prediction child jobs, in GB.}
 
 \item{notifications}{Optional, model status notifications. See
 \code{\link{scripts_post_custom}} for further documentation about email

--- a/man/civis_ml_gradient_boosting_regressor.Rd
+++ b/man/civis_ml_gradient_boosting_regressor.Rd
@@ -130,13 +130,14 @@ The default is \code{"fail"}.}
 It will have \code{" Train"} or \code{" Predict"} added to become the Script title.}
 
 \item{cpu_requested}{Optional, the number of CPU shares requested in the
-Civis Platform for training jobs. 1024 shares = 1 CPU.}
+Civis Platform for training jobs or prediction child jobs.
+1024 shares = 1 CPU.}
 
 \item{memory_requested}{Optional, the memory requested from Civis Platform
-for training jobs, in MiB.}
+for training jobs or prediction child jobs, in MiB.}
 
 \item{disk_requested}{Optional, the disk space requested on Civis Platform
-for training jobs, in GB.}
+for training jobs or prediction child jobs, in GB.}
 
 \item{notifications}{Optional, model status notifications. See
 \code{\link{scripts_post_custom}} for further documentation about email

--- a/man/civis_ml_random_forest_classifier.Rd
+++ b/man/civis_ml_random_forest_classifier.Rd
@@ -121,13 +121,14 @@ The default is \code{"fail"}.}
 It will have \code{" Train"} or \code{" Predict"} added to become the Script title.}
 
 \item{cpu_requested}{Optional, the number of CPU shares requested in the
-Civis Platform for training jobs. 1024 shares = 1 CPU.}
+Civis Platform for training jobs or prediction child jobs.
+1024 shares = 1 CPU.}
 
 \item{memory_requested}{Optional, the memory requested from Civis Platform
-for training jobs, in MiB.}
+for training jobs or prediction child jobs, in MiB.}
 
 \item{disk_requested}{Optional, the disk space requested on Civis Platform
-for training jobs, in GB.}
+for training jobs or prediction child jobs, in GB.}
 
 \item{notifications}{Optional, model status notifications. See
 \code{\link{scripts_post_custom}} for further documentation about email

--- a/man/civis_ml_random_forest_regressor.Rd
+++ b/man/civis_ml_random_forest_regressor.Rd
@@ -106,13 +106,14 @@ The default is \code{"fail"}.}
 It will have \code{" Train"} or \code{" Predict"} added to become the Script title.}
 
 \item{cpu_requested}{Optional, the number of CPU shares requested in the
-Civis Platform for training jobs. 1024 shares = 1 CPU.}
+Civis Platform for training jobs or prediction child jobs.
+1024 shares = 1 CPU.}
 
 \item{memory_requested}{Optional, the memory requested from Civis Platform
-for training jobs, in MiB.}
+for training jobs or prediction child jobs, in MiB.}
 
 \item{disk_requested}{Optional, the disk space requested on Civis Platform
-for training jobs, in GB.}
+for training jobs or prediction child jobs, in GB.}
 
 \item{notifications}{Optional, model status notifications. See
 \code{\link{scripts_post_custom}} for further documentation about email

--- a/man/civis_ml_sparse_linear_regressor.Rd
+++ b/man/civis_ml_sparse_linear_regressor.Rd
@@ -60,13 +60,14 @@ The default is \code{"fail"}.}
 It will have \code{" Train"} or \code{" Predict"} added to become the Script title.}
 
 \item{cpu_requested}{Optional, the number of CPU shares requested in the
-Civis Platform for training jobs. 1024 shares = 1 CPU.}
+Civis Platform for training jobs or prediction child jobs.
+1024 shares = 1 CPU.}
 
 \item{memory_requested}{Optional, the memory requested from Civis Platform
-for training jobs, in MiB.}
+for training jobs or prediction child jobs, in MiB.}
 
 \item{disk_requested}{Optional, the disk space requested on Civis Platform
-for training jobs, in GB.}
+for training jobs or prediction child jobs, in GB.}
 
 \item{notifications}{Optional, model status notifications. See
 \code{\link{scripts_post_custom}} for further documentation about email

--- a/man/civis_ml_sparse_logistic.Rd
+++ b/man/civis_ml_sparse_logistic.Rd
@@ -112,13 +112,14 @@ The default is \code{"fail"}.}
 It will have \code{" Train"} or \code{" Predict"} added to become the Script title.}
 
 \item{cpu_requested}{Optional, the number of CPU shares requested in the
-Civis Platform for training jobs. 1024 shares = 1 CPU.}
+Civis Platform for training jobs or prediction child jobs.
+1024 shares = 1 CPU.}
 
 \item{memory_requested}{Optional, the memory requested from Civis Platform
-for training jobs, in MiB.}
+for training jobs or prediction child jobs, in MiB.}
 
 \item{disk_requested}{Optional, the disk space requested on Civis Platform
-for training jobs, in GB.}
+for training jobs or prediction child jobs, in GB.}
 
 \item{notifications}{Optional, model status notifications. See
 \code{\link{scripts_post_custom}} for further documentation about email

--- a/man/civis_ml_sparse_ridge_regressor.Rd
+++ b/man/civis_ml_sparse_ridge_regressor.Rd
@@ -93,13 +93,14 @@ The default is \code{"fail"}.}
 It will have \code{" Train"} or \code{" Predict"} added to become the Script title.}
 
 \item{cpu_requested}{Optional, the number of CPU shares requested in the
-Civis Platform for training jobs. 1024 shares = 1 CPU.}
+Civis Platform for training jobs or prediction child jobs.
+1024 shares = 1 CPU.}
 
 \item{memory_requested}{Optional, the memory requested from Civis Platform
-for training jobs, in MiB.}
+for training jobs or prediction child jobs, in MiB.}
 
 \item{disk_requested}{Optional, the disk space requested on Civis Platform
-for training jobs, in GB.}
+for training jobs or prediction child jobs, in GB.}
 
 \item{notifications}{Optional, model status notifications. See
 \code{\link{scripts_post_custom}} for further documentation about email

--- a/tests/testthat/test_civis_ml.R
+++ b/tests/testthat/test_civis_ml.R
@@ -53,6 +53,8 @@ test_that("calls scripts_post_custom", {
              notifications = list(successEmailSubject = "A success",
                                   successEmailAddresses = c("user@example.com")),
              polling_interval = 5,
+             validation_data = "skip",
+             n_jobs = 9,
              verbose = FALSE)
   )
 
@@ -84,6 +86,8 @@ test_that("calls scripts_post_custom", {
   expect_equal(ml_args$REQUIRED_CPU, 1111)
   expect_equal(ml_args$REQUIRED_MEMORY, 9096)
   expect_equal(ml_args$REQUIRED_DISK_SPACE, 9)
+  expect_equal(ml_args$VALIDATION_DATA, "skip")
+  expect_equal(ml_args$N_JOBS, 9)
 
   # Make sure we started the job.
   expect_args(fake_scripts_post_custom_runs, 1, 999)
@@ -350,6 +354,9 @@ test_that("calls scripts_post_custom", {
             output_db = "score_database",
             if_output_exists = "append",
             n_jobs = 10,
+            cpu_requested = 2000,
+            memory_requested = 10,
+            disk_requested = 15,
             polling_interval = 5,
             verbose = TRUE)
   )
@@ -366,6 +373,9 @@ test_that("calls scripts_post_custom", {
   expect_equal(pred_args$PRIMARY_KEY, "row_number")
   expect_equal(pred_args$IF_EXISTS, "append")
   expect_equal(pred_args$N_JOBS, 10)
+  expect_equal(pred_args$CPU, 2000)
+  expect_equal(pred_args$MEMORY, 10)
+  expect_equal(pred_args$DISK_SPACE, 15)
   expect_equal(pred_args$DEBUG, TRUE)
   expect_equal(pred_args$CIVIS_FILE_ID, NULL)
   expect_equal(pred_args$TABLE_NAME, "schema.table")
@@ -428,9 +438,9 @@ test_that("uploads local df and passes a file_id", {
               if_output_exists = 'fail',
               model_name = "model_task",
               n_jobs = NULL,
-              cpu = NULL,
-              memory = NULL,
-              disk_space = NULL,
+              cpu_requested= NULL,
+              memory_requested= NULL,
+              disk_requested = NULL,
               polling_interval = NULL,
               verbose = FALSE,
               file_id = 1234)
@@ -460,9 +470,9 @@ test_that("uploads a local file and passes a file_id", {
               if_output_exists = 'fail',
               model_name = "model_task",
               n_jobs = NULL,
-              cpu = NULL,
-              memory = NULL,
-              disk_space = NULL,
+              cpu_requested= NULL,
+              memory_requested= NULL,
+              disk_requested = NULL,
               polling_interval = NULL,
               verbose = FALSE,
               file_id = 561)
@@ -486,9 +496,9 @@ test_that("passes a file_id directly", {
               if_output_exists = 'fail',
               model_name = "model_task",
               n_jobs = NULL,
-              cpu = NULL,
-              memory = NULL,
-              disk_space = NULL,
+              cpu_requested= NULL,
+              memory_requested= NULL,
+              disk_requested = NULL,
               polling_interval = NULL,
               verbose = FALSE,
               file_id = 1234)
@@ -512,9 +522,9 @@ test_that("passes a manifest file_id", {
               if_output_exists = 'fail',
               model_name = "model_task",
               n_jobs = NULL,
-              cpu = NULL,
-              memory = NULL,
-              disk_space = NULL,
+              cpu_requested= NULL,
+              memory_requested= NULL,
+              disk_requested = NULL,
               polling_interval = NULL,
               verbose = FALSE,
               manifest = 123)
@@ -547,9 +557,9 @@ test_that("passes table info", {
               if_output_exists = 'fail',
               model_name = "model_task",
               n_jobs = NULL,
-              cpu = NULL,
-              memory = NULL,
-              disk_space = NULL,
+              cpu_requested= NULL,
+              memory_requested= NULL,
+              disk_requested = NULL,
               polling_interval = NULL,
               verbose = FALSE,
               table_name = "a_schema.table",

--- a/tests/testthat/test_civis_ml.R
+++ b/tests/testthat/test_civis_ml.R
@@ -133,6 +133,8 @@ test_that("calls civis_ml.data.frame for local df", {
                 cpu_requested = NULL,
                 memory_requested = NULL,
                 disk_requested = NULL,
+                validation_data = 'train',
+                n_jobs = NULL,
                 notifications = NULL,
                 verbose = FALSE)
   )
@@ -179,6 +181,8 @@ test_that("calls civis_ml.civis_table for table_name", {
               cpu_requested = NULL,
               memory_requested = NULL,
               disk_requested = NULL,
+              validation_data = 'train',
+              n_jobs = NULL,
               notifications = NULL,
               verbose = FALSE)
 })
@@ -214,6 +218,8 @@ test_that("calls civis_ml.civis_file for file_id", {
               cpu_requested = NULL,
               memory_requested = NULL,
               disk_requested = NULL,
+              validation_data = 'train',
+              n_jobs = NULL,
               notifications = NULL,
               verbose = FALSE)
 })
@@ -255,6 +261,8 @@ test_that("calls civis_ml.character for local csv", {
               cpu_requested = NULL,
               memory_requested = NULL,
               disk_requested = NULL,
+              validation_data = 'train',
+              n_jobs = NULL,
               notifications = NULL,
               verbose = FALSE)
 })
@@ -420,6 +428,9 @@ test_that("uploads local df and passes a file_id", {
               if_output_exists = 'fail',
               model_name = "model_task",
               n_jobs = NULL,
+              cpu = NULL,
+              memory = NULL,
+              disk_space = NULL,
               polling_interval = NULL,
               verbose = FALSE,
               file_id = 1234)
@@ -449,6 +460,9 @@ test_that("uploads a local file and passes a file_id", {
               if_output_exists = 'fail',
               model_name = "model_task",
               n_jobs = NULL,
+              cpu = NULL,
+              memory = NULL,
+              disk_space = NULL,
               polling_interval = NULL,
               verbose = FALSE,
               file_id = 561)
@@ -472,6 +486,9 @@ test_that("passes a file_id directly", {
               if_output_exists = 'fail',
               model_name = "model_task",
               n_jobs = NULL,
+              cpu = NULL,
+              memory = NULL,
+              disk_space = NULL,
               polling_interval = NULL,
               verbose = FALSE,
               file_id = 1234)
@@ -495,6 +512,9 @@ test_that("passes a manifest file_id", {
               if_output_exists = 'fail',
               model_name = "model_task",
               n_jobs = NULL,
+              cpu = NULL,
+              memory = NULL,
+              disk_space = NULL,
               polling_interval = NULL,
               verbose = FALSE,
               manifest = 123)
@@ -527,6 +547,9 @@ test_that("passes table info", {
               if_output_exists = 'fail',
               model_name = "model_task",
               n_jobs = NULL,
+              cpu = NULL,
+              memory = NULL,
+              disk_space = NULL,
               polling_interval = NULL,
               verbose = FALSE,
               table_name = "a_schema.table",
@@ -681,25 +704,6 @@ test_that("uses the correct template_id", {
 
   run_args <- mock_args(fake_run_model)[[1]]
   expect_equal(run_args$template_id, 8888)
-})
-
-test_that("adds resources when n_jobs = 1", {
-  fake_getOption <- mock(8888, cycle = TRUE)
-  fake_run_model <- mock(list(job_id = 133, run_id = 244))
-  fake_fetch_predict_results <- mock(NULL)
-
-  with_mock(
-    `base::getOption` = fake_getOption,
-    `civis::run_model` = fake_run_model,
-    `civis::fetch_predict_results` = fake_fetch_predict_results,
-
-    create_and_run_pred(train_job_id = 111, train_run_id = 222, n_jobs = 1)
-  )
-
-  run_args <- mock_args(fake_run_model)[[1]]
-  expect_equal(run_args$arguments$REQUIRED_CPU, 1024)
-  expect_equal(run_args$arguments$REQUIRED_MEMORY, 3000)
-  expect_equal(run_args$arguments$REQUIRED_DISK_SPACE, 30)
 })
 
 ###############################################################################


### PR DESCRIPTION
This PR adds `validation_data` and `n_jobs` as arguments for training, and `cpu`, `memory`, and `disk_space` as arguments for prediction.