### PR TITLE
[RCL-191] FIX: tests pass with new testthat

### DIFF
--- a/tests/testthat/test_civis_future.R
+++ b/tests/testthat/test_civis_future.R
@@ -1,13 +1,16 @@
 context("civis_future")
 library(civis)
 library(future)
+library(mockery)
 
 mock_r_eval <- function(fut) {
-  # anything in inst/ is actually installed in the package root.
-  # note: devtools provides a system.file that makes tests and checks pass when run interactively.
   r_remote_eval <- parse(system.file("scripts", "r_remote_eval.R", package = "civis"))
+
+  # so you can delete expressions.
+  # this deletes the commandArgs lines, which can no longer be mocked.
+  r_remote_eval[2:3] <- NULL
+
   with_mock(
-    `base::commandArgs` = function(...) list("123"),
     `civis::read_civis` = function(...) fut,
     `civis::scripts_post_containers_runs_outputs` = function(...) NULL,
     `civis::write_civis_file` = function(...) NULL,

--- a/tests/testthat/test_civis_ml.R
+++ b/tests/testthat/test_civis_ml.R
@@ -19,7 +19,6 @@ test_that("calls scripts_post_custom", {
   fake_scripts_post_custom_runs <- mock(list(id = 888))
   fake_scripts_get_custom_runs <- mock(list(state = "running"), list(state = "succeeded"))
   fake_civis_ml_fetch_existing <- mock(NULL)
-  fake_getOption <- mock(1111, cycle = TRUE)
 
   with_mock(
     `civis::get_database_id` = fake_get_database_id,
@@ -27,7 +26,6 @@ test_that("calls scripts_post_custom", {
     `civis::scripts_post_custom_runs` = fake_scripts_post_custom_runs,
     `civis::scripts_get_custom_runs` = fake_scripts_get_custom_runs,
     `civis::civis_ml_fetch_existing` = fake_civis_ml_fetch_existing,
-    `base::getOption` = fake_getOption,
 
     tbl <- civis_table(table_name = "schema.table",
                        database_name = "a_database",
@@ -57,7 +55,7 @@ test_that("calls scripts_post_custom", {
   )
 
   script_args <- mock_args(fake_scripts_post_custom)[[1]]
-  expect_equal(script_args$from_template_id, 1111)
+  expect_equal(script_args$from_template_id, getOption("civis.ml_train_template_id"))
   expect_equal(script_args$name, "awesome civisml Train")
   expect_equal(script_args$notifications, list(successEmailSubject = "A success",
                                                successEmailAddresses = c("user@example.com")))
@@ -94,15 +92,11 @@ test_that("calls scripts_post_custom", {
 })
 
 test_that("calls civis_ml.data.frame for local df", {
-  fake_write_csv <- mock(NULL)
-  fake_temp_file <- mock("fake_temp_path")
   fake_write_civis_file <- mock(1234)
   fake_get_database_id <- mock(456)
   fake_create_and_run_model <- mock(NULL)
 
   with_mock(
-    `utils::write.csv` = fake_write_csv,
-    `base::tempfile` = fake_temp_file,
     `civis::write_civis_file` = fake_write_civis_file,
     `civis::get_database_id` = fake_get_database_id,
     `civis::create_and_run_model` = fake_create_and_run_model,
@@ -111,10 +105,6 @@ test_that("calls civis_ml.data.frame for local df", {
              model_type = "sparse_logistic",
              dependent_variable = "the_target_column",
              primary_key = "the_pk_column"),
-
-    expect_args(fake_write_civis_file, 1,
-                path = "fake_temp_path",
-                name = "modelpipeline_data.csv"),
 
     expect_args(fake_create_and_run_model, 1,
                 file_id = 1234,
@@ -321,7 +311,6 @@ test_that("calls scripts_post_custom", {
   fake_scripts_post_custom_runs <- mock(list(id = 888))
   fake_scripts_get_custom_runs <- mock(list(state = "running"), list(state = "succeeded"))
   fake_fetch_predict_results <- mock(NULL)
-  fake_getOption <- mock(1111, cycle = TRUE)
 
   with_mock(
     `civis::get_database_id` = fake_get_database_id,
@@ -329,7 +318,6 @@ test_that("calls scripts_post_custom", {
     `civis::scripts_post_custom_runs` = fake_scripts_post_custom_runs,
     `civis::scripts_get_custom_runs` = fake_scripts_get_custom_runs,
     `civis::fetch_predict_results` = fake_fetch_predict_results,
-    `base::getOption` = fake_getOption,
 
     tbl <- civis_table(table_name = "schema.table",
                        database_name = "a_database",
@@ -347,7 +335,7 @@ test_that("calls scripts_post_custom", {
   )
 
   script_args <- mock_args(fake_scripts_post_custom)[[1]]
-  expect_equal(script_args$from_template_id, 1111)
+  expect_equal(script_args$from_template_id,  getOption("civis.ml_predict_template_id"))
   expect_equal(script_args$name, "model_task Predict")
 
   # These are template args/params:
@@ -392,24 +380,15 @@ test_that("uses training primary_key by default", {
 })
 
 test_that("uploads local df and passes a file_id", {
-  fake_write_csv <- mock(NULL)
-  fake_temp_file <- mock("fake_temp_path")
   fake_write_civis_file <- mock(1234)
   fake_create_and_run_pred <- mock(NULL)
 
   with_mock(
-    `utils::write.csv` = fake_write_csv,
-    `base::tempfile` = fake_temp_file,
     `civis::write_civis_file` = fake_write_civis_file,
     `civis::create_and_run_pred` = fake_create_and_run_pred,
 
     predict(fake_model, iris, primary_key = NULL)
   )
-
-  expect_args(fake_write_csv, 1,
-              iris,
-              file = "fake_temp_path",
-              row.names = FALSE)
 
   expect_args(fake_create_and_run_pred, 1,
               train_job_id = fake_model$job$id,
@@ -540,12 +519,10 @@ test_that("passes table info", {
 context("create_and_run_model")
 
 test_that("uses the correct template_id", {
-  fake_getOption <- mock(999999, cycle = TRUE)
   fake_run_model <- mock(list(job_id = 133, run_id = 244))
   fake_civis_ml_fetch_existing <- mock(NULL)
 
   with_mock(
-    `base::getOption` = fake_getOption,
     `civis::run_model` = fake_run_model,
     `civis::civis_ml_fetch_existing` = fake_civis_ml_fetch_existing,
 
@@ -553,19 +530,16 @@ test_that("uses the correct template_id", {
   )
 
   run_args <- mock_args(fake_run_model)[[1]]
-  expect_equal(run_args$template_id, 999999)
+  expect_equal(run_args$template_id, getOption("civis.ml_train_template_id"))
 })
 
 test_that("converts parameters arg to JSON string", {
-  fake_getOption <- mock(999999, cycle = TRUE)
   fake_run_model <- mock(list(job_id = 133, run_id = 244))
   fake_civis_ml_fetch_existing <- mock(NULL)
 
   with_mock(
-    `base::getOption` = fake_getOption,
     `civis::run_model` = fake_run_model,
     `civis::civis_ml_fetch_existing` = fake_civis_ml_fetch_existing,
-
     create_and_run_model(file_id = 123, parameters = list(n_trees = 500, c = -1))
   )
 
@@ -574,12 +548,10 @@ test_that("converts parameters arg to JSON string", {
 })
 
 test_that("converts cross_validation_parameters to JSON string", {
-  fake_getOption <- mock(999999, cycle = TRUE)
   fake_run_model <- mock(list(job_id = 133, run_id = 244))
   fake_civis_ml_fetch_existing <- mock(NULL)
 
   with_mock(
-    `base::getOption` = fake_getOption,
     `civis::run_model` = fake_run_model,
     `civis::civis_ml_fetch_existing` = fake_civis_ml_fetch_existing,
 
@@ -593,12 +565,10 @@ test_that("converts cross_validation_parameters to JSON string", {
 })
 
 test_that("converts fit_params to JSON string", {
-  fake_getOption <- mock(999999, cycle = TRUE)
   fake_run_model <- mock(list(job_id = 133, run_id = 244))
   fake_civis_ml_fetch_existing <- mock(NULL)
 
   with_mock(
-    `base::getOption` = fake_getOption,
     `civis::run_model` = fake_run_model,
     `civis::civis_ml_fetch_existing` = fake_civis_ml_fetch_existing,
 
@@ -611,15 +581,12 @@ test_that("converts fit_params to JSON string", {
 })
 
 test_that("space separates excluded_columns", {
-  fake_getOption <- mock(999999, cycle = TRUE)
   fake_run_model <- mock(list(job_id = 133, run_id = 244))
   fake_civis_ml_fetch_existing <- mock(NULL)
 
   with_mock(
-    `base::getOption` = fake_getOption,
     `civis::run_model` = fake_run_model,
     `civis::civis_ml_fetch_existing` = fake_civis_ml_fetch_existing,
-
     create_and_run_model(file_id = 132, excluded_columns = c("c1", "c2", "c3"))
   )
 
@@ -628,12 +595,10 @@ test_that("space separates excluded_columns", {
 })
 
 test_that("space separates target_column", {
-  fake_getOption <- mock(999999, cycle = TRUE)
   fake_run_model <- mock(list(job_id = 133, run_id = 244))
   fake_civis_ml_fetch_existing <- mock(NULL)
 
   with_mock(
-    `base::getOption` = fake_getOption,
     `civis::run_model` = fake_run_model,
     `civis::civis_ml_fetch_existing` = fake_civis_ml_fetch_existing,
 
@@ -646,15 +611,12 @@ test_that("space separates target_column", {
 })
 
 test_that("file_id is always numeric", {
-  fake_getOption <- mock(999999, cycle = TRUE)
   fake_run_model <- mock(list(job_id = 133, run_id = 244))
   fake_civis_ml_fetch_existing <- mock(NULL)
 
   with_mock(
-    `base::getOption` = fake_getOption,
     `civis::run_model` = fake_run_model,
     `civis::civis_ml_fetch_existing` = fake_civis_ml_fetch_existing,
-
     create_and_run_model(file_id = civis_file(132))
   )
 
@@ -667,39 +629,17 @@ test_that("file_id is always numeric", {
 context("create_and_run_pred")
 
 test_that("uses the correct template_id", {
-  fake_getOption <- mock(8888, cycle = TRUE)
   fake_run_model <- mock(list(job_id = 133, run_id = 244))
   fake_fetch_predict_results <- mock(NULL)
 
   with_mock(
-    `base::getOption` = fake_getOption,
     `civis::run_model` = fake_run_model,
     `civis::fetch_predict_results` = fake_fetch_predict_results,
-
     create_and_run_pred(train_job_id = 111, train_run_id = 222)
   )
 
   run_args <- mock_args(fake_run_model)[[1]]
-  expect_equal(run_args$template_id, 8888)
-})
-
-test_that("adds resources when n_jobs = 1", {
-  fake_getOption <- mock(8888, cycle = TRUE)
-  fake_run_model <- mock(list(job_id = 133, run_id = 244))
-  fake_fetch_predict_results <- mock(NULL)
-
-  with_mock(
-    `base::getOption` = fake_getOption,
-    `civis::run_model` = fake_run_model,
-    `civis::fetch_predict_results` = fake_fetch_predict_results,
-
-    create_and_run_pred(train_job_id = 111, train_run_id = 222, n_jobs = 1)
-  )
-
-  run_args <- mock_args(fake_run_model)[[1]]
-  expect_equal(run_args$arguments$REQUIRED_CPU, 1024)
-  expect_equal(run_args$arguments$REQUIRED_MEMORY, 3000)
-  expect_equal(run_args$arguments$REQUIRED_DISK_SPACE, 30)
+  expect_equal(run_args$template_id, getOption("civis.ml_predict_template_id"))
 })
 
 ###############################################################################
@@ -849,24 +789,18 @@ context("fetch_oos_scores")
 
 test_that("it checks input type", {
   fake_must_fetch_output_file <- mock(NULL)
-  fake_read_csv <- mock(NULL)
 
   with_mock(
-    `utils::read.csv` = fake_read_csv,
     `civis::must_fetch_output_file` = fake_must_fetch_output_file,
-
     expect_error(fetch_oos_scores("not a model"), "is_civis_ml(model) is not TRUE", fixed = TRUE)
   )
 })
 
 test_that("it looks for predictions.csv.gz", {
-  fake_must_fetch_output_file <- mock(NULL)
-  fake_read_csv <- mock(NULL)
+  fake_must_fetch_output_file <- mock(textConnection(c("a, b, c")))
 
   with_mock(
-    `utils::read.csv` = fake_read_csv,
     `civis::must_fetch_output_file` = fake_must_fetch_output_file,
-
     fetch_oos_scores(structure(list(), class = "civis_ml"))
   )
 
@@ -875,19 +809,15 @@ test_that("it looks for predictions.csv.gz", {
 })
 
 test_that("it calls read.csv with extra args", {
-  fake_must_fetch_output_file <- mock("a_file.csv")
-  fake_read_csv <- mock(NULL)
+  fake_must_fetch_output_file <- mock(textConnection(c("a,b,c")))
 
-  with_mock(
-    `utils::read.csv` = fake_read_csv,
+  df <- with_mock(
     `civis::must_fetch_output_file` = fake_must_fetch_output_file,
-
-    fetch_oos_scores(structure(list(), class = "civis_ml"), stringsAsFactors = FALSE)
+    fetch_oos_scores(structure(list(), class = "civis_ml"),
+                           stringsAsFactors = FALSE, header = FALSE)
   )
-
-  csv_args <- mock_args(fake_read_csv)[[1]]
-  expect_equal(csv_args[[1]], "a_file.csv")
-  expect_equal(csv_args$stringsAsFactors, FALSE)
+  ans <- data.frame(V1 = "a", V2 = "b", V3 = "c", stringsAsFactors = FALSE)
+  expect_equal(df, ans)
 })
 
 
@@ -900,18 +830,16 @@ test_that("it checks input type", {
 
 test_that("it calls read.csv with extra args, and dowload_civis with correct id", {
   fake_read_csv <- mock(NULL)
-  fake_download_civis <- mock("path.csv")
+  fake_download_civis <- mock(textConnection(c("a,b,c")))
 
-  with_mock(
-    `utils::read.csv` = fake_read_csv,
+  df <- with_mock(
     `civis::fetch_predict_results` = function(...) list(model_info = list(output_file_ids = 1)),
     `civis::download_civis` = fake_download_civis,
-    fetch_predictions(structure(list(), class = "civis_ml_prediction"), stringsAsFactors = FALSE)
+    fetch_predictions(structure(list(), class = "civis_ml_prediction"),
+                      header = FALSE, stringsAsFactors = FALSE)
   )
-
-  csv_args <- mock_args(fake_read_csv)[[1]]
-  expect_equal(csv_args[[1]], "path.csv")
-  expect_equal(csv_args$stringsAsFactors, FALSE)
+  ans <- data.frame(V1 = "a", V2 = "b", V3 = "c", stringsAsFactors = FALSE)
+  expect_equal(df, ans)
 
   dl_args <- mock_args(fake_download_civis)[[1]]
   expect_equal(dl_args[[1]], 1)


### PR DESCRIPTION
The only major change here is that we can't mock functions in `base` or `utils`. We can do so with minimal loss in test coverage.

@keithing for review