### PR TITLE
[RCL-192] ENH: Adding an Rstudio Addin to publish RMD to platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ swagger.json
 inst/doc
 inst/web
 .Rproj.user
+.*.swp
+.*.swo

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,8 @@ Suggests:
     rmarkdown,
     DBItest,
     mockery,
-    R.utils
+    R.utils,
+    rstudioapi
 RoxygenNote: 6.0.1
 VignetteBuilder: knitr
 Collate: 
@@ -61,6 +62,7 @@ Collate:
     'logs.R'
     'pagination_helpers.R'
     'reports.R'
+    'rstudio.R'
     'tables.R'
     'utils.R'
     'zzz.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,8 @@ Suggests:
     DBItest,
     mockery,
     R.utils,
-    rstudioapi
+    rstudioapi,
+    yaml
 RoxygenNote: 6.0.1
 VignetteBuilder: knitr
 Collate: 

--- a/R/reports.R
+++ b/R/reports.R
@@ -131,7 +131,7 @@ wrap_in_scrolling_div <- function(html) {
 }
 
 
-#' Simple RMarkdown YAML front matter parser. For a more robust parser,
+# Simple RMarkdown YAML front matter parser. For a more robust parser,
 # see rmarkdown::render.
 parse_front_matter <- function(rmd_file) {
   metadata <- tryCatch({

--- a/R/reports.R
+++ b/R/reports.R
@@ -12,6 +12,21 @@
 #' is not explicity set and \code{input} will be overwritten with
 #' \code{rmd_file}.
 #'
+#' @details
+#' This function also supports passing \code{report_id}, \code{report_name},
+#' \code{provide_api_key} and \code{project_id} as metadata in the report's
+#' YAML front matter.  Just as the title of an RMarkdown document can be set
+#' with \code{title: "my title!"}, these parameters can be set like
+#' \preformatted{
+#'   civis:
+#'     report_name: "My Report Name"
+#'     report_id: 9000
+#' }
+#' Since \code{report_id} is set, this code will overwrite the existing
+#' report with that number, which may be useful when updating a report on
+#' a schedule.  Any argument passed in explicity to \code{publish_rmd}
+#' will be used in place of the corresponding argument set in YAML metadata.
+#'
 #' @note
 #' \code{rmarkdown::render} depends on a recent version of \code{pandoc}.
 #' \code{pandoc} is distributed with RStudio and thus, \code{publish_rmd}
@@ -38,6 +53,17 @@ publish_rmd <- function(rmd_file, report_id=NULL, report_name=NULL,
                         provide_api_key=NULL, project_id=NULL, ...) {
   render_args <- list(...)
 
+  # Look for publish_html args in the yaml of the RMarkdown file, overwriting
+  # the arg if it is explicity passed into publish_rmd
+  html_args <- parse_front_matter(rmd_file)[["civis"]]
+  html_args <- if (is.null(html_args)) list() else html_args
+  if (!missing(report_id)) html_args[["report_id"]] <- report_id
+  if (!missing(report_name)) html_args[["report_name"]] <- report_name
+  if (!missing(project_id)) html_args[["project_id"]] <- project_id
+  if (!missing(provide_api_key)) {
+    html_args[["provide_api_key"]] <- provide_api_key
+  }
+
   # Ensure "rmd_file" is used over "input" in "..."
   if (!is.null(render_args[["input"]])) {
     warning("parameter 'input' is ignored. Using 'rmd_file' instead.")
@@ -49,11 +75,9 @@ publish_rmd <- function(rmd_file, report_id=NULL, report_name=NULL,
     if (is.null(render_args[["output_file"]])) {
       render_args[["output_file"]] <- temp_output
     }
+    html_args[["html_file"]] <- render_args[["output_file"]]
     do.call(rmarkdown::render, render_args)
-    publish_html(render_args[["output_file"]],
-                 report_id, report_name,
-                 provide_api_key = provide_api_key,
-                 project_id = project_id)
+    do.call(publish_html, html_args)
   }, finally = {
     unlink(temp_output)
   })
@@ -104,4 +128,30 @@ wrap_in_scrolling_div <- function(html) {
   head <- '<div style="overflow-y:scroll;height:100%">'
   tail <- '</div>'
   paste0(head, "\n", html, "\n", tail)
+}
+
+
+#' Simple RMarkdown YAML front matter parser. For a more robust parser,
+# see rmarkdown::render.
+parse_front_matter <- function(rmd_file) {
+  metadata <- tryCatch({
+    rmd_lines <- readLines(rmd_file)
+    delim <- grep("^---\\s*$", rmd_lines)
+    start <- delim[1] + 1  # First yaml line is line after first ---
+    end <- delim[2] - 1 # Last yaml line is line before second ---
+    if (is.na(start) | is.na(end)) {
+      list()
+    } else if (end - start < 1) {
+      list()
+    } else {
+      yaml_str <- paste(rmd_lines[start:end], collapse="\n")
+      yaml::yaml.load(yaml_str)
+    }
+  }, error = function(e) {
+    msg <- paste("Failed to parse Civis metadata from Rmarkdown file:",
+                 e$message)
+    warning(msg, call. = FALSE)
+    list()
+  })
+  metadata
 }

--- a/R/rstudio.R
+++ b/R/rstudio.R
@@ -1,0 +1,20 @@
+#' Add in to Publish an R Markdown file to Platform Reports from RStudio
+publish_addin <- function() {
+  context <- rstudioapi::getSourceEditorContext()
+  path <- context[["path"]]
+  if (path == "") stop("Please save file before publishing.")
+  if (tolower(tools::file_ext(path)) != "rmd") {
+    stop("Only RMarkdown files with the .Rmd extension are supported.")
+  }
+
+  # documentSave only available in Rstudio >= 1.1.287
+  if (rstudioapi::hasFun("documentSave")) {
+    rstudioapi::documentSave(context$id)
+  }
+
+  report_id <- publish_rmd(rmd_file = path)
+  url <- paste0("https://platform.civisanalytics.com/#/reports/",
+                report_id,
+                "?fullscreen=true")
+  browseURL(url)
+}

--- a/R/rstudio.R
+++ b/R/rstudio.R
@@ -16,5 +16,5 @@ publish_addin <- function() {
   url <- paste0("https://platform.civisanalytics.com/#/reports/",
                 report_id,
                 "?fullscreen=true")
-  browseURL(url)
+  utils::browseURL(url)
 }

--- a/inst/rstudio/addins.dcf
+++ b/inst/rstudio/addins.dcf
@@ -1,0 +1,4 @@
+Name: Publish To Civis
+Description: Publishes current document to the Civis Platform (currently only supports RMarkdown)
+Binding: publish_addin
+Interactive: false

--- a/man/publish_rmd.Rd
+++ b/man/publish_rmd.Rd
@@ -28,6 +28,21 @@ is not explicity set and \code{input} will be overwritten with
 \description{
 Publish an R Markdown file to Platform Reports
 }
+\details{
+This function also supports passing \code{report_id}, \code{report_name},
+\code{provide_api_key} and \code{project_id} as metadata in the report's
+YAML front matter.  Just as the title of an RMarkdown document can be set
+with \code{title: "my title!"}, these parameters can be set like
+\preformatted{
+  civis:
+    report_name: "My Report Name"
+    report_id: 9000
+}
+Since \code{report_id} is set, this code will overwrite the existing
+report with that number, which may be useful when updating a report on
+a schedule.  Any argument passed in explicity to \code{publish_rmd}
+will be used in place of the corresponding argument set in YAML metadata.
+}
 \note{
 \code{rmarkdown::render} depends on a recent version of \code{pandoc}.
 \code{pandoc} is distributed with RStudio and thus, \code{publish_rmd}

--- a/tests/testthat/test_rstudio.R
+++ b/tests/testthat/test_rstudio.R
@@ -1,0 +1,42 @@
+library(civis)
+context("rstudio")
+
+test_that("publish_addin errors nicely when no path is present", {
+  mock_context <- list(path="", id="")  # path is empty here
+  mockery::stub(publish_addin, "browseURL", NULL)
+  with_mock(
+    `rstudioapi::getSourceEditorContext` = function(...) mock_context,
+    `rstudioapi::hasFun` = function(...) FALSE,
+    `rstudioapi::documentSave` = function(...) FALSE,
+    `civis::publish_rmd` = function(...) 123,
+    expect_error(publish_addin(), "Please save file before publishing.")
+  )
+})
+
+test_that("publish_addin errors nicely when path is not RMarkdown", {
+  mock_context <- list(path="not_rmd.txt", id="")  # path is not .rmd here
+  mockery::stub(publish_addin, "browseURL", NULL)
+  with_mock(
+    `rstudioapi::getSourceEditorContext` = function(...) mock_context,
+    `rstudioapi::hasFun` = function(...) FALSE,
+    `rstudioapi::documentSave` = function(...) FALSE,
+    `civis::publish_rmd` = function(...) 123,
+    expect_error(publish_addin(), "Only RMarkdown files.*")
+  )
+})
+
+test_that("publish_addin opens the correct url", {
+  # test_that 2.0 cannot mock base R functions, use mockery instead
+  mock_browseurl <- mockery::mock()
+  mock_context <- list(path="fake.Rmd", id="")
+  mockery::stub(publish_addin, "browseURL", mock_browseurl)
+  url <- "https://platform.civisanalytics.com/#/reports/123?fullscreen=true"
+  with_mock(
+    `rstudioapi::getSourceEditorContext` = function(...) mock_context,
+    `rstudioapi::hasFun` = function(...) FALSE,
+    `rstudioapi::documentSave` = function(...) FALSE,
+    `civis::publish_rmd` = function(...) 123,
+    publish_addin()
+  )
+  expect_args(mock_browseurl, 1, url)
+})

--- a/tests/testthat/test_rstudio.R
+++ b/tests/testthat/test_rstudio.R
@@ -3,7 +3,7 @@ context("rstudio")
 
 test_that("publish_addin errors nicely when no path is present", {
   mock_context <- list(path="", id="")  # path is empty here
-  mockery::stub(publish_addin, "browseURL", NULL)
+  mockery::stub(publish_addin, "utils::browseURL", NULL)
   with_mock(
     `rstudioapi::getSourceEditorContext` = function(...) mock_context,
     `rstudioapi::hasFun` = function(...) FALSE,
@@ -15,7 +15,7 @@ test_that("publish_addin errors nicely when no path is present", {
 
 test_that("publish_addin errors nicely when path is not RMarkdown", {
   mock_context <- list(path="not_rmd.txt", id="")  # path is not .rmd here
-  mockery::stub(publish_addin, "browseURL", NULL)
+  mockery::stub(publish_addin, "utils::browseURL", NULL)
   with_mock(
     `rstudioapi::getSourceEditorContext` = function(...) mock_context,
     `rstudioapi::hasFun` = function(...) FALSE,
@@ -29,7 +29,7 @@ test_that("publish_addin opens the correct url", {
   # test_that 2.0 cannot mock base R functions, use mockery instead
   mock_browseurl <- mockery::mock()
   mock_context <- list(path="fake.Rmd", id="")
-  mockery::stub(publish_addin, "browseURL", mock_browseurl)
+  mockery::stub(publish_addin, "utils::browseURL", mock_browseurl)
   url <- "https://platform.civisanalytics.com/#/reports/123?fullscreen=true"
   with_mock(
     `rstudioapi::getSourceEditorContext` = function(...) mock_context,


### PR DESCRIPTION
This PR makes 2 changes:

1. `publish_rmd` now looks at the YAML of RMarkdown files for parameters.  This allows users to hard code parameters like `report_name` and `report_id` into the markdown file itself.  For example:

```
---
title: "RMarkdown Title"
civis:
  report_name: "My Report Name"
  report_id: 390232
---

RMarkdown text here ...
```

2.  This creates an RStudio addin "Publish to Civis" which will publish an RMarkdown file directly to a report a platform.  If `report_id` is hard coded in the YAML of the RMarkdown file, the same report will be updated, allowing users to easily change a report.