### PR TITLE
[RCL-202] resolved future

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.2.0] - Unreleased
+
+### Fixed
+
+- `resolved.CivisFuture` now gets the status of the platform job directly and updates the state of the future.
+
+### Added
+
+- `value.CivisFuture` now prints error logs from failed jobs, throws a catcheable
+error, and fetches the job logs automatically.
+
 ## [1.1.1] - 2017-11-20
 
 ### Fixed

--- a/R/civis_future.R
+++ b/R/civis_future.R
@@ -69,7 +69,7 @@ CivisFuture <- function(expr = NULL,
                         label = NULL,
                         required_resources = list(cpu = 1024, memory = 2048, diskSpace = 4),
                         docker_image_name = "civisanalytics/datascience-r",
-                        docker_image_tag = "2.2.0",
+                        docker_image_tag = "2.3.0",
                          ...) {
 
   gp <- future::getGlobalsAndPackages(expr, envir = envir, globals = globals)

--- a/R/civis_future.R
+++ b/R/civis_future.R
@@ -10,7 +10,15 @@ NULL
 #' @examples \dontrun{
 #'  plan(civis_platform)
 #'  fut <- future({2 + 2}, required_resources = list(cpu = 1024, memory = 2048))
+#'
+#'  # check if a future as resolved
+#'  resolved(fut)
+#'
+#'  # block until the future resolves, and return the value
 #'  value(fut)
+#'
+#'  # grab the run logs
+#'  fut$logs
 #' }
 #'
 #' @export
@@ -43,7 +51,7 @@ CivisFuture <- function(expr = NULL,
                         label = NULL,
                         required_resources = list(cpu = 1024, memory = 2048, diskSpace = 4),
                         docker_image_name = "civisanalytics/datascience-r",
-                        docker_image_tag = "2.0.0",
+                        docker_image_tag = "2.2.0",
                          ...) {
 
   gp <- future::getGlobalsAndPackages(expr, envir = envir, globals = globals)
@@ -75,17 +83,20 @@ CivisFuture <- function(expr = NULL,
 
 #' @export
 run.CivisFuture <- function(future, ...) {
-  cargo <- c(expr = future$expr, envir = future$envir, packages = list(future$packages))
-  task_file_id <- write_civis_file(cargo)
-  runner_file_id <- upload_runner_script()
-  cmd <- make_docker_cmd(task_file_id, runner_file_id)
-  future$job <- scripts_post_containers(future$required_resources,
-                                        docker_command = cmd,
-                                        docker_image_name = future$docker_image_name,
-                                        docker_image_tag = future$docker_image_tag, ...)
-  future$job <- scripts_post_containers_runs(future$job$id)
-  future$state <- c("running")
-  future
+  if (is.null(future$job$containerId)) {
+    cargo <- c(expr = future$expr, envir = future$envir,
+               packages = list(future$packages))
+    task_file_id <- write_civis_file(cargo)
+    runner_file_id <- upload_runner_script()
+    cmd <- make_docker_cmd(task_file_id, runner_file_id)
+    future$job <- scripts_post_containers(future$required_resources,
+                                          docker_command = cmd,
+                                          docker_image_name = future$docker_image_name,
+                                          docker_image_tag = future$docker_image_tag, ...)
+    future$job <- scripts_post_containers_runs(future$job$id)
+    future$state <- c("running")
+  }
+  return(future)
 }
 
 #' @export
@@ -93,17 +104,19 @@ value.CivisFuture <- function(future, ...) {
   if (future$state == "created") {
     future <- run(future)
   }
-  if (!future$state %in% c("succeeded", "failed", "cancelled")) {
-    # get the run from the future object
+  # if the value isn't collected, try to collect it.
+  if (is.null(future$value)) {
     tryCatch({
-      runs <- await(scripts_get_containers_runs, id = future$job$containerId, run_id = future$job$id)
-      future$state <- runs$state
-      future$run <- runs
-      future$value <- fetch_output(runs)
-    }, error = function(e) {
+      future$run <- await(scripts_get_containers_runs, id = future$job$containerId,
+                          run_id = future$job$id)
+      future$state <- future$run$state
+      future$value <- fetch_output(future$run)
+      future$logs  <- fetch_logs(future$run)
+    }, civis_error = function(e) {
       future$state <- "failed"
+      e$message <- paste0(c(e$message, fetch_logs(e)), collapse = "\n")
       stop(e)
-    })
+    }, error = function(e) stop(e))
   }
   future$value
 }
@@ -124,13 +137,16 @@ cancel.CivisFuture <- function(future, ...) {
 
 #' @export
 resolved.CivisFuture <- function(future, ...){
+  if (!is.null(future$job$containerId)) {
+    future$state <- scripts_get_containers_runs(id = future$job$containerId,
+                                              run_id = future$job$id)$state
+  }
   future$state %in% c("succeeded", "failed", "cancelled")
 }
 
 #' @export
 fetch_logs.CivisFuture <- function(object, limit, ...){
-  logs <- scripts_list_containers_runs_logs(object$job$containerId, run_id = object$job$id, limit = limit)
-  format_scripts_logs(logs)
+  object$logs
 }
 
 fetch_output <- function(run) {

--- a/R/civis_future.R
+++ b/R/civis_future.R
@@ -8,17 +8,35 @@ NULL
 #' @param ... Arguments to \code{\link{CivisFuture}} and then \code{\link{scripts_post_containers}}
 #' @return The result of evaluating \code{expr}.
 #' @examples \dontrun{
-#'  plan(civis_platform)
-#'  fut <- future({2 + 2}, required_resources = list(cpu = 1024, memory = 2048))
 #'
-#'  # check if a future as resolved
+#'  plan(civis_platform)
+#'
+#'  # Specify required resources, image, and tag.
+#'  fut <- future({2 + 2},
+#'    required_resources = list(cpu = 1024, memory = 2048),
+#'    docker_image_name = "civisanalytics/datascience-r",
+#'    docker_image_tag = "2.2.0")
+#'
+#'  # Evaluate the future later
+#'  fut <- future({2 + 2}, lazy = TRUE)
+#'  run(fut)
+#'
+#'  # check if a future has resolved
 #'  resolved(fut)
 #'
-#'  # block until the future resolves, and return the value
+#'  # block until the future resolves, and return the value or throw error
 #'  value(fut)
 #'
+#'  # cancel the job
+#'  cancel(fut)
+#'
 #'  # grab the run logs
-#'  fut$logs
+#'  fetch_logs(fut)
+#'
+#'  # handle errors
+#'  fut <- future({stop("Error!")})
+#'  e <- tryCatch(value(fut), error = function(e) e)
+#'  get_error(e)
 #' }
 #'
 #' @export

--- a/man/CivisFuture.Rd
+++ b/man/CivisFuture.Rd
@@ -9,7 +9,7 @@ CivisFuture(expr = NULL, envir = parent.frame(), substitute = FALSE,
   gc = FALSE, earlySignal = FALSE, label = NULL,
   required_resources = list(cpu = 1024, memory = 2048, diskSpace = 4),
   docker_image_name = "civisanalytics/datascience-r",
-  docker_image_tag = "2.0.0", ...)
+  docker_image_tag = "2.2.0", ...)
 }
 \arguments{
 \item{expr}{An R \link[base]{expression}.}

--- a/man/civis_platform.Rd
+++ b/man/civis_platform.Rd
@@ -17,9 +17,35 @@ This is used as with the \code{\link{future}} API as an argument to \code{\link{
 }
 \examples{
 \dontrun{
+
  plan(civis_platform)
- fut <- future({2 + 2}, required_resources = list(cpu = 1024, memory = 2048))
+
+ # Specify required resources, image, and tag.
+ fut <- future({2 + 2},
+   required_resources = list(cpu = 1024, memory = 2048),
+   docker_image_name = "civisanalytics/datascience-r",
+   docker_image_tag = "2.2.0")
+
+ # Evaluate the future later
+ fut <- future({2 + 2}, lazy = TRUE)
+ run(fut)
+
+ # check if a future has resolved
+ resolved(fut)
+
+ # block until the future resolves, and return the value or throw error
  value(fut)
+
+ # cancel the job
+ cancel(fut)
+
+ # grab the run logs
+ fetch_logs(fut)
+
+ # handle errors
+ fut <- future({stop("Error!")})
+ e <- tryCatch(value(fut), error = function(e) e)
+ get_error(e)
 }
 
 }

--- a/tests/testthat/test_civis_future.R
+++ b/tests/testthat/test_civis_future.R
@@ -45,13 +45,41 @@ mock_run <- function(expr) {
     `civis::scripts_post_containers_runs_outputs` = function(...) NULL,
     `civis::scripts_get_containers_runs` = function(...) list(state = "succeeded"),
     `civis::fetch_output` = function(...) mock_r_eval(fut),
-    value(run(fut))
+    `civis::fetch_logs` = function(...) list("a log"),
+    list(fut = run(fut), value = value(fut))
   )
 }
 
 test_that("run and value work", {
   out <- capture.output(res <- mock_run(quote(2 + 3)))
-  expect_equal(res, 5)
+  expect_equal(res$value, 5)
+  expect_equal(res$fut$logs, list("a log"))
+  expect_equal(res$fut$state, "succeeded")
+  # shouldn't need to be mocked
+  expect_equal(value(res$fut), res$val)
+})
+
+mock_err <- function(expr) {
+  fut <- CivisFuture(expr)
+  with_mock(
+    `civis::write_civis_file` = function(...) 123,
+    `civis::upload_runner_script` = function(...) "",
+    `civis::scripts_post_containers` = function(...) NULL,
+    `civis::scripts_post_containers_runs` = function(...) list(containerId = 1, id = 2),
+    `civis::scripts_post_containers_runs_outputs` = function(...) NULL,
+    `civis::scripts_get_containers_runs` = function(id, run_id) list(state = "failed"),
+    `civis::fetch_output` = function(...) NULL,
+    `civis::fetch_logs` = function(...) list("error_log"),
+    list(fut = run(fut), value = value(fut))
+  )
+}
+
+test_that("run and value handle errors", {
+  e <- tryCatch(mock_err(quote(2 + 3)), error = function(e) e)
+  expect_is(e, "civis_error")
+  msg <- "scripts_get_containers_runs(id = 1, run_id = 2): \nerror_log"
+  expect_equal(e$message, msg)
+  expect_equal(attributes(e)$args, list(id = 1, run_id = 2))
 })
 
 test_that("CivisFuture has the right stuff", {
@@ -72,8 +100,11 @@ test_that("CivisFuture has the right stuff", {
 })
 
 test_that("resolved", {
-  fut <- CivisFuture(quote(2 + 2))
-  expect_false(resolved(fut))
+  with_mock(
+    `civis::scripts_get_containers_runs` = function(...) list(state = "running"),
+    fut <- CivisFuture(quote(2 + 2)),
+    expect_false(resolved(fut))
+  )
 })
 
 test_that("cancel", {
@@ -84,5 +115,4 @@ test_that("cancel", {
   )
   expect_equal(fut$state, "cancelled")
 })
-
 

--- a/tests/testthat/test_civis_ml.R
+++ b/tests/testthat/test_civis_ml.R
@@ -50,7 +50,7 @@ test_that("calls scripts_post_custom", {
              disk_requested = 9,
              notifications = list(successEmailSubject = "A success",
                                   successEmailAddresses = c("user@example.com")),
-             polling_interval = 5,
+             polling_interval = .01,
              validation_data = "skip",
              n_jobs = 9,
              verbose = FALSE)
@@ -325,14 +325,18 @@ test_that("calls scripts_post_custom", {
   fake_scripts_post_custom <- mock(list(id = 999))
   fake_scripts_post_custom_runs <- mock(list(id = 888))
   fake_scripts_get_custom_runs <- mock(list(state = "running"), list(state = "succeeded"))
+  fake_scripts_get_custom <- mock(list(state = "succeeded"), cycle = TRUE)
   fake_fetch_predict_results <- mock(NULL)
+
 
   with_mock(
     `civis::get_database_id` = fake_get_database_id,
     `civis::scripts_post_custom` = fake_scripts_post_custom,
     `civis::scripts_post_custom_runs` = fake_scripts_post_custom_runs,
+    `civis::scripts_get_custom` = fake_scripts_get_custom,
     `civis::scripts_get_custom_runs` = fake_scripts_get_custom_runs,
     `civis::fetch_predict_results` = fake_fetch_predict_results,
+
 
     tbl <- civis_table(table_name = "schema.table",
                        database_name = "a_database",
@@ -348,7 +352,7 @@ test_that("calls scripts_post_custom", {
             cpu_requested = 2000,
             memory_requested = 10,
             disk_requested = 15,
-            polling_interval = 5,
+            polling_interval = .01,
             verbose = TRUE)
   )
 


### PR DESCRIPTION
`resolved` now polls the job from platform. This is useful in shiny apps, which can do polling for you without blocking. 

I also add error handling in the usual fashion, by just printing the log. 

```
fut <- future({ stop("asdf") })
value(fut)
```
![screen shot 2017-12-05 at 4 49 31 pm](https://user-images.githubusercontent.com/427445/33635144-6e0c4aaa-d9dc-11e7-9a2f-dfaff602470e.png)

Finally, I also fixed a test that was taking too long, dropping our test times to about ~10s from ~15s.