### PR TITLE
ENH tryCatch for missing metrics files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 - `value.CivisFuture` now prints error logs from failed jobs, throws a catcheable
 error, and fetches the job logs automatically.
 
+### Changed
+
+- `civis_ml_fetch_existing` can handle runs with missing
+  `metrics.json` files.
+
 ## [1.1.1] - 2017-11-20
 
 ### Fixed

--- a/R/civis_ml.R
+++ b/R/civis_ml.R
@@ -666,7 +666,8 @@ civis_ml_fetch_existing <- function(model_id, run_id = NULL) {
   outputs <- metrics <- model_info <- NULL
   if (run$state == "succeeded") {
     outputs <- scripts_list_custom_runs_outputs(id = model_id, run_id = run_id)
-    metrics <- must_fetch_output_json(outputs, "metrics.json")
+    metrics <- tryCatch(must_fetch_output_json(outputs, "metrics.json"),
+                        error = function(e) NULL)
     model_info <- must_fetch_output_json(outputs, "model_info.json")
   }
   type <- model_type(job)

--- a/tests/testthat/test_civis_ml.R
+++ b/tests/testthat/test_civis_ml.R
@@ -686,6 +686,28 @@ test_that("exceptions with hyperband correct", {
   )
 })
 
+test_that("robust if metrics.json not present", {
+  fn <- tempfile()
+  cat(jsonlite::toJSON(c("a,b,c")), file = fn)
+
+  fake_outputs <- mock(list(list(objectType = "File", objectId = 1, name = "model_info.json")))
+  fake_download <- mock(fn)
+  fake_fetch_job <- mock(1)
+  fake_fetch_run <- mock(list(state = "succeeded"))
+  fake_model_type <- mock("regressor")
+  res <- with_mock(
+    `civis::must_fetch_civis_ml_job` = fake_fetch_job,
+    `civis::must_fetch_civis_ml_run` = fake_fetch_run,
+    `civis::scripts_list_custom_runs_outputs` = fake_outputs,
+    `civis::download_civis` = fake_download,
+    `civis::model_type` = fake_model_type,
+    civis_ml_fetch_existing(123, 1)
+  )
+  expect_equal(res$model_info, c("a,b,c"))
+  expect_null(res$metrics)
+})
+
+
 
 ################################################################################
 # run predictions


### PR DESCRIPTION
CivisML no longer writes `metrics.json` files when validation is skipped. To handle this, I've added a `tryCatch` around reading in the metrics file.

I didn't add a test for this because my mock-fu isn't strong enough. I wanted to add a test with `must_fetch_output_json` mocked so that fetching `metrics.json` errored but not `model_info.json`. Any thoughts on how to test the new behavior, @patr1ckm? I did test manually and the fix works with an actual run from Platform.