### PR TITLE
ENH "dvs_to_predict" option for model predictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `query_civis_file` exports a `"schema.tablename"`, `sql("query")`, or existing sql script id to S3 and returns the file id.
 - `write_civis` gains a `diststyle` argument for controlling the distribution of tables on Redshift.
+- `predict.civis_ml` and `create_and_run_pred` gain a `dvs_to_predict` argument which allows users to restrict output predictions to a subset of targets from a multi-output model.
 
 ### Changed
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,7 @@ Authors@R: c(
   person("Anh", "Le", email = "ale@civisanalytics.com", role = "ctb"),
   person("Michelangelo", "D'Agostino", email = "mdagostino@civisanalytics.com", role = "ctb"),
   person("Sam", "Weiss", email = "sweiss@civisanalytics.com", role = "ctb"),
+  person("Stephen", "Hoover", email = "shoover@civisanalytics.com", role = "ctb"),
   person("Danning", "Chen", email = "dchen@civisanalytics.com", role = "ctb"))
 Description: A set of tools around common workflows and a convenient interface to make
   requests directly to the 'Civis data science API' <https://www.civisanalytics.com/platform/>.
@@ -45,7 +46,7 @@ Suggests:
     yaml
 RoxygenNote: 6.0.1
 VignetteBuilder: knitr
-Collate: 
+Collate:
     'await.R'
     'civis_future.R'
     'civis_ml.R'

--- a/R/civis_ml.R
+++ b/R/civis_ml.R
@@ -74,6 +74,9 @@
 #' @param dvs_to_predict Optional, For scoring, this should be a vector of column
 #'   names of dependent variables to include in the output table. It must be a
 #'   subset of the \code{dependent_variable} vector provided for training.
+#'   The scores for the returned subset will be identical to the scores which
+#'   those outputs would have had if all outputs were written, but ignoring some
+#'   of the model's outputs will let predictions complete faster and use less disk space.
 #'   If not provided, the entire model output will be written to the output table.
 #' @param \dots Unused
 #'

--- a/R/civis_ml.R
+++ b/R/civis_ml.R
@@ -71,6 +71,10 @@
 #'   data for validation, and \code{skip}, which skips the validation step.
 #' @param verbose Optional, If \code{TRUE}, supply debug outputs in Platform
 #'   logs and make prediction child jobs visible.
+#' @param dvs_to_predict Optional, For scoring, this should be a vector of column
+#'   names of dependent variables to include in the output table. It must be a
+#'   subset of the \code{dependent_variable} vector provided for training.
+#'   If not provided, the entire model output will be written to the output table.
 #' @param \dots Unused
 #'
 #' @section CivisML Workflows:
@@ -752,6 +756,7 @@ predict.civis_ml <- function(object,
                              disk_requested = NULL,
                              polling_interval = NULL,
                              verbose = FALSE,
+                             dvs_to_predict = NULL,
                              ...) {
 
   output_db_id <- NULL
@@ -811,6 +816,10 @@ predict.civis_ml <- function(object,
     pred_args[["sql_limit"]] <- newdata$sql_limit
   }
 
+  if (!is.null(dvs_to_predict)) {
+    pred_args[["dvs_to_predict"]] <- paste(dvs_to_predict, collapse = " ")
+  }
+
   do.call(create_and_run_pred, pred_args)
 }
 
@@ -834,7 +843,8 @@ create_and_run_pred <- function(train_job_id = NULL,
                                 disk_requested = NULL,
                                 polling_interval = NULL,
                                 notifications = NULL,
-                                verbose = FALSE) {
+                                verbose = FALSE,
+                                dvs_to_predict = NULL) {
   args <- list(
     TRAIN_JOB = train_job_id,
     TRAIN_RUN = train_run_id,
@@ -881,6 +891,10 @@ create_and_run_pred <- function(train_job_id = NULL,
 
   if (!is.null(disk_requested)) {
     args[["DISK_SPACE"]] <- disk_requested
+  }
+
+  if (!is.null(dvs_to_predict)) {
+    args[["TARGET_COLUMN"]] <- paste(dvs_to_predict, collapse = " ")
   }
 
   args <- I(args)

--- a/man/civis_ml.Rd
+++ b/man/civis_ml.Rd
@@ -22,7 +22,7 @@ civis_ml_fetch_existing(model_id, run_id = NULL)
   output_table = NULL, output_db = NULL, if_output_exists = c("fail",
   "append", "drop", "truncate"), n_jobs = NULL, cpu_requested = NULL,
   memory_requested = NULL, disk_requested = NULL, polling_interval = NULL,
-  verbose = FALSE, ...)
+  verbose = FALSE, dvs_to_predict = NULL, ...)
 }
 \arguments{
 \item{x, newdata}{See the Data Sources section below.}
@@ -119,6 +119,14 @@ the model was built.}
 
 \item{if_output_exists}{Action to take if the prediction table already exists. One of \code{"fail"}, \code{"append"}, \code{"drop"}, or \code{"truncate"}.
 The default is \code{"fail"}.}
+
+\item{dvs_to_predict}{Optional, For scoring, this should be a vector of column
+names of dependent variables to include in the output table. It must be a
+subset of the \code{dependent_variable} vector provided for training.
+The scores for the returned subset will be identical to the scores which
+those outputs would have had if all outputs were written, but ignoring some
+of the model's outputs will let predictions complete faster and use less disk space.
+If not provided, the entire model output will be written to the output table.}
 
 \item{\dots}{Unused}
 }


### PR DESCRIPTION
CivisML v2.2 will include the ability for users to select a subset of targets from a multi-target model to write to the scoring table. If users only care about a subset of the model's outputs, they can save time and disk space by only keeping those predictions.