### PR TITLE
ENH print CivisML warnings when model results fetched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Print CivisML training warnings when model results are fetched from Platform.
 - `query_civis_file` exports a `"schema.tablename"`, `sql("query")`, or existing sql script id to S3 and returns the file id.
 - `write_civis` gains a `diststyle` argument for controlling the distribution of tables on Redshift.
 - `predict.civis_ml` and `create_and_run_pred` gain a `dvs_to_predict` argument which allows users to restrict output predictions to a subset of targets from a multi-output model.

--- a/R/civis_ml.R
+++ b/R/civis_ml.R
@@ -694,6 +694,12 @@ civis_ml_fetch_existing <- function(model_id, run_id = NULL) {
                         error = function(e) NULL)
     model_info <- must_fetch_output_json(outputs, "model_info.json")
   }
+
+  # re-raise any CivisML warnings
+  for(warn in model_info$warnings){
+    cat(warn)
+  }
+  
   type <- model_type(job)
 
   structure(
@@ -919,6 +925,11 @@ fetch_predict_results <- function(job_id, run_id) {
   run <- scripts_get_custom_runs(job_id, run_id)
   outputs <- scripts_list_custom_runs_outputs(job_id, run_id)
   model_info <- must_fetch_output_json(outputs, "model_info.json")
+
+  # re-raise any CivisML warnings
+  for(warn in model_info$warnings){
+    cat(warn)
+  }
 
   structure(
     list(

--- a/R/civis_ml.R
+++ b/R/civis_ml.R
@@ -693,13 +693,11 @@ civis_ml_fetch_existing <- function(model_id, run_id = NULL) {
     metrics <- tryCatch(must_fetch_output_json(outputs, "metrics.json"),
                         error = function(e) NULL)
     model_info <- must_fetch_output_json(outputs, "model_info.json")
+    # re-raise any CivisML warnings
+    tryCatch( {for (warn in model_info$warnings) cat(warn)},
+             error = function(err) { return(NULL) })
   }
 
-  # re-raise any CivisML warnings
-  for(warn in model_info$warnings){
-    cat(warn)
-  }
-  
   type <- model_type(job)
 
   structure(
@@ -927,9 +925,8 @@ fetch_predict_results <- function(job_id, run_id) {
   model_info <- must_fetch_output_json(outputs, "model_info.json")
 
   # re-raise any CivisML warnings
-  for(warn in model_info$warnings){
-    cat(warn)
-  }
+  tryCatch( {for (warn in model_info$warnings) cat(warn)},
+           error = function(err) { return(NULL) })
 
   structure(
     list(

--- a/R/civis_ml.R
+++ b/R/civis_ml.R
@@ -693,8 +693,9 @@ civis_ml_fetch_existing <- function(model_id, run_id = NULL) {
                         error = function(e) NULL)
     model_info <- must_fetch_output_json(outputs, "model_info.json")
     # re-raise any CivisML warnings
-    tryCatch( {for (warn in model_info$warnings) cat(warn)},
-             error = function(err) { return(NULL) })
+    if (length(model_info$warnings) > 0) {
+      warning("CivisML issued the following warnings during training:\n", unlist(model_info$warnings))
+    }
   }
 
   type <- model_type(job)
@@ -924,8 +925,9 @@ fetch_predict_results <- function(job_id, run_id) {
   model_info <- must_fetch_output_json(outputs, "model_info.json")
 
   # re-raise any CivisML warnings
-  tryCatch( {for (warn in model_info$warnings) cat(warn)},
-           error = function(err) { return(NULL) })
+  if (length(model_info$warnings) > 0) {
+    warning("CivisML issued the following warnings during training:\n", unlist(model_info$warnings))
+  }
 
   structure(
     list(

--- a/tests/testthat/test_civis_ml.R
+++ b/tests/testthat/test_civis_ml.R
@@ -684,7 +684,7 @@ test_that("exceptions with hyperband correct", {
 
 test_that("robust if metrics.json not present", {
   fn <- tempfile()
-  cat(jsonlite::toJSON(c("a,b,c")), file = fn)
+  cat(jsonlite::toJSON(list(a=1, b=letters[1:3])), file = fn)
 
   fake_outputs <- mock(list(list(objectType = "File", objectId = 1, name = "model_info.json")))
   fake_download <- mock(fn)
@@ -699,7 +699,7 @@ test_that("robust if metrics.json not present", {
     `civis::model_type` = fake_model_type,
     civis_ml_fetch_existing(123, 1)
   )
-  expect_equal(res$model_info, c("a,b,c"))
+  expect_equal(res$model_info, list(a=1, b=letters[1:3]))
   expect_null(res$metrics)
 })
 


### PR DESCRIPTION
In the python client, fetching CivisML models causes CivisML warnings to print to the screen, instead of keeping them buried in the metadata. This PR replicates that behavior in the R client.

Right now, I just have the warnings print without any annotation, even though they are Python warnings printing to an R console. If you think this needs to be clarified for the user, let me know.