### PR TITLE
ENH add feather support for local dataframes being sent to CivisML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Local dataframes can now be sent to CivisML as feather files
 - Print CivisML training warnings when model results are fetched from Platform.
 - `query_civis_file` exports a `"schema.tablename"`, `sql("query")`, or existing sql script id to S3 and returns the file id.
 - `write_civis` gains a `diststyle` argument for controlling the distribution of tables on Redshift.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Imports:
     dplyr (>= 0.7.0),
     dbplyr (>= 1.0.0),
     devtools,
+    feather,
     future (>= 1.6.1),
     ggplot2,
     httr,
@@ -38,7 +39,6 @@ Imports:
     testthat,
     utils
 Suggests:
-    feather,
     knitr,
     rmarkdown,
     DBItest,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,8 @@ Authors@R: c(
   person("Michelangelo", "D'Agostino", email = "mdagostino@civisanalytics.com", role = "ctb"),
   person("Sam", "Weiss", email = "sweiss@civisanalytics.com", role = "ctb"),
   person("Stephen", "Hoover", email = "shoover@civisanalytics.com", role = "ctb"),
-  person("Danning", "Chen", email = "dchen@civisanalytics.com", role = "ctb"))
+  person("Danning", "Chen", email = "dchen@civisanalytics.com", role = "ctb"),
+  person("Elizabeth", "Sander", email = "lsander@civisanalytics.com", role = "ctb"))
 Description: A set of tools around common workflows and a convenient interface to make
   requests directly to the 'Civis data science API' <https://www.civisanalytics.com/platform/>.
 Depends:
@@ -37,6 +38,7 @@ Imports:
     testthat,
     utils
 Suggests:
+    feather,
     knitr,
     rmarkdown,
     DBItest,

--- a/R/civis_ml.R
+++ b/R/civis_ml.R
@@ -515,6 +515,10 @@ civis_ml.character <- function(x,
 #' Try to stash a dataframe in feather format, for applicable CivisML versions.
 #' Otherwise, stash as csv. If any columns are factor, require feather format,
 #' to avoid incorrect type inference reading from csv.
+#'
+#' @param x data.frame to stash
+#'
+#' @return file id where dataframe is stored
 stash_local_dataframe <- function(x) {
   # Try to stash a dataframe in feather format.
   tmpl_id <- getOption("civis.ml_train_template_id")

--- a/R/civis_ml.R
+++ b/R/civis_ml.R
@@ -518,7 +518,7 @@ civis_ml.character <- function(x,
 #'
 #' @return file id where dataframe is stored
 stash_local_dataframe <- function(x) {
-  # Try to stash a dataframe in feathenr format.
+  # Try to stash a dataframe in feather format.
   tmpl_id <- getOption("civis.ml_train_template_id")
   tmp_path <- tempfile()
 

--- a/R/civis_ml.R
+++ b/R/civis_ml.R
@@ -520,29 +520,20 @@ civis_ml.character <- function(x,
 #'
 #' @return file id where dataframe is stored
 stash_local_dataframe <- function(x) {
-  # Try to stash a dataframe in feather format.
+  # Try to stash a dataframe in feathenr format.
   tmpl_id <- getOption("civis.ml_train_template_id")
   tmp_path <- tempfile()
 
-  civis_path <- tryCatch({
-    if (tmpl_id > 9969) {
-      # newer versions preferentially use feather
-      feather::write_feather(x, tmp_path)
-      civis_path <- "modelpipeline_data.feather"
-    } else {
-      # older versions can't use feather
-      utils::write.csv(x, file = tmp_path, row.names = FALSE)
-      civis_path <- "modelpipeline_data.csv"
-    }
-  }, error = function(e) {
-    # don't allow new versions to write to csv if there are factors
-    if (any(sapply(x, is.factor))) {
-      stop('Factor columns can only be handled with "feather" installed')
-    }
-    # fall back to writing to csv
+  if (tmpl_id > 9969) {
+    # newer versions use feather
+    feather::write_feather(x, tmp_path)
+    civis_path <- "modelpipeline_data.feather"
+  } else {
+    # older versions can't use feather
     utils::write.csv(x, file = tmp_path, row.names = FALSE)
-    return("modelpipeline_data.csv")
-  })
+    civis_path <- "modelpipeline_data.csv"
+  }
+
   file_id <- write_civis_file(tmp_path, name = civis_path)
   return(file_id)
 }

--- a/R/civis_ml.R
+++ b/R/civis_ml.R
@@ -512,9 +512,7 @@ civis_ml.character <- function(x,
                        verbose = verbose)
 }
 
-#' Try to stash a dataframe in feather format, for applicable CivisML versions.
-#' Otherwise, stash as csv. If any columns are factor, require feather format,
-#' to avoid incorrect type inference reading from csv.
+#' Stash a data frame in feather or csv format, depending on CivisML version.
 #'
 #' @param x data.frame to stash
 #'

--- a/R/civis_ml.R
+++ b/R/civis_ml.R
@@ -326,9 +326,7 @@ civis_ml.data.frame <- function(x,
     oos_scores_db_id <- get_database_id(oos_scores_db)
   }
 
-  tmp_path <- tempfile()
-  utils::write.csv(x, file = tmp_path, row.names = FALSE)
-  file_id <- write_civis_file(tmp_path, "modelpipeline_data.csv")
+  file_id <- stash_local_dataframe(x)
   create_and_run_model(file_id = file_id,
                        dependent_variable = dependent_variable,
                        excluded_columns = excluded_columns,
@@ -512,6 +510,37 @@ civis_ml.character <- function(x,
                        n_jobs = n_jobs,
                        notifications = notifications,
                        verbose = verbose)
+}
+
+#' Try to stash a dataframe in feather format, for applicable CivisML versions.
+#' Otherwise, stash as csv. If any columns are factor, require feather format,
+#' to avoid incorrect type inference reading from csv.
+stash_local_dataframe <- function(x) {
+  # Try to stash a dataframe in feather format.
+  tmpl_id <- getOption("civis.ml_train_template_id")
+  tmp_path <- tempfile()
+
+  civis_path <- tryCatch({
+    if (tmpl_id > 9969) {
+      # newer versions preferentially use feather
+      feather::write_feather(x, tmp_path)
+      civis_path <- "modelpipeline_data.feather"
+    } else {
+      # older versions can't use feather
+      utils::write.csv(x, file = tmp_path, row.names = FALSE)
+      civis_path <- "modelpipeline_data.csv"
+    }
+  }, error = function(e) {
+    # don't allow new versions to write to csv if there are factors
+    if (any(sapply(x, is.factor))) {
+      stop('Factor columns can only be handled with "feather" installed')
+    }
+    # fall back to writing to csv
+    utils::write.csv(x, file = tmp_path, row.names = FALSE)
+    return("modelpipeline_data.csv")
+  })
+  file_id <- write_civis_file(tmp_path, name = civis_path)
+  return(file_id)
 }
 
 create_and_run_model <- function(file_id = NULL,

--- a/tests/testthat/test_civis_ml.R
+++ b/tests/testthat/test_civis_ml.R
@@ -599,43 +599,6 @@ test_that("older CivisML versions use csv", {
   options(civis.ml_train_template_id = temp_id)
 })
 
-test_that("newer CivisML version without feather falls back to csv", {
-  # enforce newer CivisML version
-  temp_id <- getOption('civis.ml_train_template_id')
-  options(civis.ml_train_template_id = 10582)
-  # can't include factors here
-  x <- data.frame(a = 1:3, b = letters[1:3], stringsAsFactors = FALSE)
-  fake_file <- mock(1)
-  fake_feather <- mock(stop('feather is gone now'))
-  with_mock(
-    `civis::write_civis_file` = fake_file,
-    `feather::write_feather` = fake_feather,
-    {
-      stash_local_dataframe(x)
-      args <- mock_args(fake_file)
-      expect_equal(args[[1]]$name, "modelpipeline_data.csv")
-    }
-  )
-  # cleanup
-  options(civis.ml_train_template_id = temp_id)
-})
-
-test_that("raises error without feather when df has factors", {
-  # enforce newer CivisML version
-  temp_id <- getOption('civis.ml_train_template_id')
-  options(civis.ml_train_template_id = 10582)
-  # b will be a factor, which should cause errors without feather
-  x <- data.frame(a = 1:3, b = letters[1:3])
-  fake_feather <- mock(stop('feather is gone now'))
-  err_msg <- 'Factor columns can only be handled with "feather" installed'
-  with_mock(
-    `feather::write_feather` = fake_feather,
-    expect_error(stash_local_dataframe(x), err_msg)
-  )
-  # cleanup
-  options(civis.ml_train_template_id = temp_id)
-})
-
 ################################################################################
 # run build model
 context("create_and_run_model")

--- a/tests/testthat/test_civis_ml.R
+++ b/tests/testthat/test_civis_ml.R
@@ -1,4 +1,5 @@
 library(mockery)
+
 context("civis_ml")
 
 test_that("jsonlite works", {
@@ -555,6 +556,84 @@ test_that("passes table info", {
               database_id = 999,
               sql_where = "row_number in (1, 2, 4)",
               sql_limit = 11)
+})
+
+################################################################################
+context("stash_local_dataframe")
+
+test_that("newer CivisML versions use feather", {
+  # enforce newer CivisML version
+  temp_id <- getOption('civis.ml_train_template_id')
+  options(civis.ml_train_template_id = 10582)
+  # factor should not cause errors when using feather
+  x <- data.frame(a = 1:3, b = letters[1:3])
+  fake_file <- mock(1)
+  with_mock(
+    `civis::write_civis_file` = fake_file,
+    {
+      stash_local_dataframe(x)
+      args <- mock_args(fake_file)
+      expect_equal(args[[1]]$name, "modelpipeline_data.feather")
+    }
+  )
+  # cleanup
+  options(civis.ml_train_template_id = temp_id)
+})
+
+test_that("older CivisML versions use csv", {
+  # enforce older CivisML version
+  temp_id <- getOption('civis.ml_train_template_id')
+  options(civis.ml_train_template_id = 9969)
+  # factor type should not matter for older version
+  x <- data.frame(a = 1:3, b = letters[1:3], stringsAsFactors = FALSE)
+  fake_file <- mock(1)
+  with_mock(
+    `civis::write_civis_file` = fake_file,
+    {
+      stash_local_dataframe(x)
+      args <- mock_args(fake_file)
+      expect_equal(args[[1]]$name, "modelpipeline_data.csv")
+    }
+  )
+  # cleanup
+  options(civis.ml_train_template_id = temp_id)
+})
+
+test_that("newer CivisML version without feather falls back to csv", {
+  # enforce newer CivisML version
+  temp_id <- getOption('civis.ml_train_template_id')
+  options(civis.ml_train_template_id = 10582)
+  # can't include factors here
+  x <- data.frame(a = 1:3, b = letters[1:3], stringsAsFactors = FALSE)
+  fake_file <- mock(1)
+  fake_feather <- mock(stop('feather is gone now'))
+  with_mock(
+    `civis::write_civis_file` = fake_file,
+    `feather::write_feather` = fake_feather,
+    {
+      stash_local_dataframe(x)
+      args <- mock_args(fake_file)
+      expect_equal(args[[1]]$name, "modelpipeline_data.csv")
+    }
+  )
+  # cleanup
+  options(civis.ml_train_template_id = temp_id)
+})
+
+test_that("raises error without feather when df has factors", {
+  # enforce newer CivisML version
+  temp_id <- getOption('civis.ml_train_template_id')
+  options(civis.ml_train_template_id = 10582)
+  # b will be a factor, which should cause errors without feather
+  x <- data.frame(a = 1:3, b = letters[1:3])
+  fake_feather <- mock(stop('feather is gone now'))
+  err_msg <- 'Factor columns can only be handled with "feather" installed'
+  with_mock(
+    `feather::write_feather` = fake_feather,
+    expect_error(stash_local_dataframe(x), err_msg)
+  )
+  # cleanup
+  options(civis.ml_train_template_id = temp_id)
 })
 
 ################################################################################


### PR DESCRIPTION
This PR adds feather support for newer versions of CivisML. This resolves a bug where users would pass local dataframes with factor-type columns, which in some cases would be written as integers in the csv, causing unexpected ETL behavior in CivisML (i.e., not categorically expanding factors).

The new behavior is as follows:
- for older versions of CivisML, there will be no change.
- for newer versions of CivisML (which support feather), the client will attempt to use feather for local dataframes by default. If the user does not have feather installed, it will fall back to csv, throwing an error if any columns are factors.

This feature matches Python client functionality: https://github.com/civisanalytics/civis-python/pull/200