### PR TITLE
Better error message for write_civis_file

### DIFF
--- a/R/io.R
+++ b/R/io.R
@@ -333,7 +333,7 @@ write_civis_file.default <- function(x, name = 'r-object.rds', expires_at = NULL
 write_civis_file.character <- function(x, name = x, expires_at = NULL, ...) {
   if (!file.exists(x)) {
     msg <- paste("File 'x' does not exist. If 'x' is a vector of characters",
-                 "to be uploaded rather than a filename, try ",
+                 "to be uploaded rather than a filename, try",
                  "write_civis_file(as.list(x), ...)")
     stop(msg)
   }

--- a/R/io.R
+++ b/R/io.R
@@ -331,7 +331,12 @@ write_civis_file.default <- function(x, name = 'r-object.rds', expires_at = NULL
 #' @describeIn write_civis_file Upload a text file to Civis Platform (Files endpoint).
 #' @export
 write_civis_file.character <- function(x, name = x, expires_at = NULL, ...) {
-  stopifnot(file.exists(x))
+  if (!file.exists(x)) {
+    msg <- paste("File 'x' does not exist. If 'x' is a vector of characters",
+                 "to be uploaded rather than a filename, try ",
+                 "write_civis_file(as.list(x), ...)")
+    stop(msg)
+  }
   size <- file.size(x)
   if (size > MAX_FILE_SIZE) stop("File larger than 5tb, can't upload.")
   if (size > MIN_MULTIPART_SIZE) {

--- a/R/io.R
+++ b/R/io.R
@@ -331,10 +331,12 @@ write_civis_file.default <- function(x, name = 'r-object.rds', expires_at = NULL
 #' @describeIn write_civis_file Upload a text file to Civis Platform (Files endpoint).
 #' @export
 write_civis_file.character <- function(x, name = x, expires_at = NULL, ...) {
-  if (!file.exists(x)) {
-    msg <- paste("File 'x' does not exist. If 'x' is a vector of characters",
-                 "to be uploaded rather than a filename, try",
-                 "write_civis_file(as.list(x), ...)")
+  if (length(x) > 1 || !file.exists(x)) {
+    err <- ifelse(length(x) > 1,
+                  "'x' has length > 1.",
+                  "File 'x' does not exist.")
+    msg <- paste(err, "If 'x' is a character vector to be uploaded rather",
+                 "than a filename, try write_civis_file(as.list(x), ...)")
     stop(msg)
   }
   size <- file.size(x)

--- a/tests/testthat/test_io.R
+++ b/tests/testthat/test_io.R
@@ -197,9 +197,13 @@ test_that("write_civis.numeric fails for NA", {
 })
 
 test_that("write_civis_file fails if file doesn't exist", {
-  msg <- "file.exists(x) is not TRUE"
-  err_msg <- tryCatch(write_civis_file("asdf"), error = function(e) e$message)
-  expect_equal(msg, err_msg)
+  regexp <- "File 'x' does not exist.*"
+  expect_error(write_civis_file("asdf"), regexp)
+})
+
+test_that("write_civis_file fails if character vector length 2 is passed", {
+  regexp <- "'x' has length > 1.*"
+  expect_error(write_civis_file(c('fake', 'paths')), regexp)
 })
 
 test_that("write_civis_file.character returns a file id", {


### PR DESCRIPTION
As we dispatch `write_civis_file` based on `character`, there is some ambiguity. This adds a slightly better error to message to `write_civis_file` to help in this situation:

```R
x <- c("some chars", "to upload", "I'm not a filename.")
write_civis_file(x)
```