### PR TITLE
FIX: remove linebreaks in parameter descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - `read_civis.numeric`, `write_civis.numeric`, `download_civis.numeric`, and `query_civis.numeric` now fail with a better error message for `NA` of type numeric.
 - The `hidden` argument of `write_civis` now works.
+- Remove new lines from parameter descriptions in generated docs.
 
 ## [1.2.0] - 2018-01-23
 

--- a/R/generate_client.R
+++ b/R/generate_client.R
@@ -317,7 +317,7 @@ is_obj <- function(x) {
 
 get_descr_str <- function(x) {
   desc <- if (!is.null(x$description)) x$description else ""
-  gsub("\n[[:space:]]+", " ", desc)
+  gsub("\n[[:space:]]*", " ", desc)
 }
 
 get_req_str <- function(x) {

--- a/R/generate_client.R
+++ b/R/generate_client.R
@@ -316,7 +316,8 @@ is_obj <- function(x) {
 }
 
 get_descr_str <- function(x) {
-  if (!is.null(x$description)) x$description else ""
+  desc <- if (!is.null(x$description)) x$description else ""
+  gsub("\n[[:space:]]+", " ", desc)
 }
 
 get_req_str <- function(x) {


### PR DESCRIPTION
A test is running here:

https://platform.civisanalytics.com/#/scripts/containers/10601923

Since it passes loading the package, we should be good to go.