### PR TITLE
Adding in future backend docs to html docs

### DIFF
--- a/_pkgdown.yaml
+++ b/_pkgdown.yaml
@@ -27,6 +27,11 @@ reference:
       desc: Named workflows for CivisML models
       contents:
       - matches("^civis_ml_(extra|random|sparse|gradient)")
+    - title: Parallel Computing
+      desc: Executing custom tasks in the Civis Platform in parallel
+      contents:
+      - civis_platform
+      - CivisFuture
     - title: dplyr
       desc: dplyr backend for remote data manipulation
       contents:


### PR DESCRIPTION
This just adds `civis_platform` and `CivisFuture` to the reference index in the docs.