### PR TITLE
ENH Update modeling to CivisML v2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- Add v2.2 CivisML templates.
+
+
 ## [1.3.0] - 2018-03-30
 
 ### Added
@@ -15,7 +21,6 @@
 
 - CivisML stacking documentation has been updated.
 - `write_civis_file` now defaults to the file path for the `name` argument instead of requiring it.
-- Add v2.2 CivisML templates.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - CivisML stacking documentation has been updated.
 - `write_civis_file` now defaults to the file path for the `name` argument instead of requiring it.
+- Add v2.2 CivisML templates.
 
 ### Fixed
 

--- a/R/civis_ml_utils.R
+++ b/R/civis_ml_utils.R
@@ -20,9 +20,9 @@ CIVIS_ML_CLASSIFIERS <- c("sparse_logistic",
                           "stacking_classifier")
 
 CIVIS_ML_TEMPLATE_IDS <- data.frame(
-  id = c(9112, 9113, 9968, 9969, 10582, 10583),
-  version = c(1.1, 1.1, 2.0, 2.0, 2.1, 2.1),
-  name = c("train", "predict", "train", "predict", "train", "predict"),
+  id = c(9112, 9113, 9968, 9969, 10582, 10583, 11219, 11220, 11221),
+  version = c(1.1, 1.1, 2.0, 2.0, 2.1, 2.1, 2.2, 2.2, 2.2),
+  name = c("train", "predict", "train", "predict", "train", "predict", "train", "predict", "register"),
   stringsAsFactors = FALSE
 )
 

--- a/tests/testthat/test_civis_ml.R
+++ b/tests/testthat/test_civis_ml.R
@@ -564,7 +564,7 @@ context("stash_local_dataframe")
 test_that("newer CivisML versions use feather", {
   # enforce newer CivisML version
   temp_id <- getOption('civis.ml_train_template_id')
-  options(civis.ml_train_template_id = 10582)
+  options(civis.ml_train_template_id = 11219)
   # factor should not cause errors when using feather
   x <- data.frame(a = 1:3, b = letters[1:3])
   fake_file <- mock(1)


### PR DESCRIPTION
Use the newly-released v2.2 templates to run Civis Platform modeling jobs.