### PR TITLE
[DOC] Tables docs, CivisFuture generics, CivisML plots

### DIFF
--- a/R/civis_future.R
+++ b/R/civis_future.R
@@ -100,6 +100,7 @@ CivisFuture <- function(expr = NULL,
 }
 
 #' @export
+#' @describeIn CivisFuture Run a CivisFuture
 run.CivisFuture <- function(future, ...) {
   if (is.null(future$job$containerId)) {
     cargo <- c(expr = future$expr, envir = future$envir,
@@ -118,6 +119,7 @@ run.CivisFuture <- function(future, ...) {
 }
 
 #' @export
+#' @describeIn CivisFuture Return the value of a CivisFuture
 value.CivisFuture <- function(future, ...) {
   if (future$state == "created") {
     future <- run(future)
@@ -148,12 +150,14 @@ cancel <- function(future, ...) {
 }
 
 #' @export
+#' @describeIn CivisFuture Cancel a CivisFuture
 cancel.CivisFuture <- function(future, ...) {
   scripts_delete_containers_runs(id = future$job$containerId, run_id = future$job$id)
   future$state <- "cancelled"
 }
 
 #' @export
+#' @describeIn CivisFuture Check if a CivisFutre has resolved
 resolved.CivisFuture <- function(future, ...){
   if (!is.null(future$job$containerId)) {
     future$state <- scripts_get_containers_runs(id = future$job$containerId,
@@ -163,6 +167,7 @@ resolved.CivisFuture <- function(future, ...){
 }
 
 #' @export
+#' @describeIn CivisFuture Fetch logs from a CivisFuture
 fetch_logs.CivisFuture <- function(object, limit, ...){
   object$logs
 }

--- a/R/civis_future.R
+++ b/R/civis_future.R
@@ -100,6 +100,7 @@ CivisFuture <- function(expr = NULL,
 }
 
 #' @export
+#' @param future CivisFuture object.
 #' @describeIn CivisFuture Run a CivisFuture
 run.CivisFuture <- function(future, ...) {
   if (is.null(future$job$containerId)) {
@@ -142,7 +143,7 @@ value.CivisFuture <- function(future, ...) {
 }
 
 #' Cancel the evaluation of a CivisFuture.
-#' @param future CivisFuture object to be cancelled.
+#' @param future CivisFuture object.
 #' @param ... unused for CivisFuture.
 #' @export
 cancel <- function(future, ...) {
@@ -167,8 +168,9 @@ resolved.CivisFuture <- function(future, ...){
 }
 
 #' @export
+#' @param object CivisFuture
 #' @describeIn CivisFuture Fetch logs from a CivisFuture
-fetch_logs.CivisFuture <- function(object, limit, ...){
+fetch_logs.CivisFuture <- function(object, ...){
   object$logs
 }
 

--- a/_pkgdown.yaml
+++ b/_pkgdown.yaml
@@ -8,30 +8,39 @@ reference:
     - title: IO
       desc: Moving data to and from the Civis Platform
       contents:
+      - download_civis
+      - query_civis
+      - query_civis_file
       - read_civis
+      - sql
       - write_civis
       - write_civis_file
-      - query_civis
-      - sql
-      - download_civis
     - title: CivisML
       desc: Training and scoring models with CivisML
       contents:
       - civis_ml
       - civis_file
-      - civis_table
       - civis_file_manifest
+      - civis_table
       - fetch_logs
       - get_metric
+      - hist.civis_ml
+      - plot.civis_ml_classifier
+      - plot.civis_ml_regressor
     - title: CivisML Workflows
       desc: Named workflows for CivisML models
       contents:
-      - matches("^civis_ml_(extra|random|sparse|gradient)")
+      - matches("^civis_ml_(extra|gradient|random|sparse)")
     - title: Parallel Computing
       desc: Executing custom tasks in the Civis Platform in parallel
       contents:
       - civis_platform
       - CivisFuture
+      - cancel.CivisFuture
+      - fetch_logs.CivisFuture
+      - resolved.CivisFuture
+      - run.CivisFuture
+      - value.CivisFuture
     - title: Reports
       desc: Publishing reports to the Civis Platform
       contents:
@@ -39,9 +48,10 @@ reference:
       - publish_html
     - title: Tables
       desc: Utilities for working with Redshift Tables
-      - transfer_table
+      contents:
       - get_table_id
       - refresh_table
+      - transfer_table
     - title: Pagination
       desc: Retrieve data from paginated endpoints
       contents:
@@ -62,7 +72,6 @@ reference:
       contents:
       - default_credential
       - get_database_id
-      - get_table_id
     - title: API
       desc: Direct API calls to the Civis Platform
       contents:

--- a/_pkgdown.yaml
+++ b/_pkgdown.yaml
@@ -37,6 +37,11 @@ reference:
       contents:
       - publish_rmd
       - publish_html
+    - title: Tables
+      desc: Utilities for working with Redshift Tables
+      - transfer_table
+      - get_table_id
+      - refresh_table
     - title: Pagination
       desc: Retrieve data from paginated endpoints
       contents:

--- a/_pkgdown.yaml
+++ b/_pkgdown.yaml
@@ -36,11 +36,6 @@ reference:
       contents:
       - civis_platform
       - CivisFuture
-      - cancel.CivisFuture
-      - fetch_logs.CivisFuture
-      - resolved.CivisFuture
-      - run.CivisFuture
-      - value.CivisFuture
     - title: Reports
       desc: Publishing reports to the Civis Platform
       contents:

--- a/man/CivisFuture.Rd
+++ b/man/CivisFuture.Rd
@@ -24,7 +24,7 @@ CivisFuture(expr = NULL, envir = parent.frame(), substitute = FALSE,
 
 \method{resolved}{CivisFuture}(future, ...)
 
-\method{fetch_logs}{CivisFuture}(object, limit, ...)
+\method{fetch_logs}{CivisFuture}(object, ...)
 }
 \arguments{
 \item{expr}{An R \link[base]{expression}.}
@@ -66,6 +66,10 @@ future.}
 \item{docker_image_tag}{the tag for the Docker image.}
 
 \item{...}{arguments to \code{\link{scripts_post_containers}}}
+
+\item{future}{CivisFuture object.}
+
+\item{object}{CivisFuture}
 }
 \value{
 A \code{CivisFuture} inheriting from \code{\link{Future}} that evaluates \code{expr} on the given container.

--- a/man/CivisFuture.Rd
+++ b/man/CivisFuture.Rd
@@ -2,6 +2,11 @@
 % Please edit documentation in R/civis_future.R
 \name{CivisFuture}
 \alias{CivisFuture}
+\alias{run.CivisFuture}
+\alias{value.CivisFuture}
+\alias{cancel.CivisFuture}
+\alias{resolved.CivisFuture}
+\alias{fetch_logs.CivisFuture}
 \title{Evaluate an expression in Civis Platform}
 \usage{
 CivisFuture(expr = NULL, envir = parent.frame(), substitute = FALSE,
@@ -10,6 +15,16 @@ CivisFuture(expr = NULL, envir = parent.frame(), substitute = FALSE,
   required_resources = list(cpu = 1024, memory = 2048, diskSpace = 4),
   docker_image_name = "civisanalytics/datascience-r",
   docker_image_tag = "2.3.0", ...)
+
+\method{run}{CivisFuture}(future, ...)
+
+\method{value}{CivisFuture}(future, ...)
+
+\method{cancel}{CivisFuture}(future, ...)
+
+\method{resolved}{CivisFuture}(future, ...)
+
+\method{fetch_logs}{CivisFuture}(object, limit, ...)
 }
 \arguments{
 \item{expr}{An R \link[base]{expression}.}
@@ -58,3 +73,16 @@ A \code{CivisFuture} inheriting from \code{\link{Future}} that evaluates \code{e
 \description{
 Evaluate an expression in Civis Platform
 }
+\section{Methods (by generic)}{
+\itemize{
+\item \code{run}: Run a CivisFuture
+
+\item \code{value}: Return the value of a CivisFuture
+
+\item \code{cancel}: Cancel a CivisFuture
+
+\item \code{resolved}: Check if a CivisFutre has resolved
+
+\item \code{fetch_logs}: Fetch logs from a CivisFuture
+}}
+

--- a/man/cancel.Rd
+++ b/man/cancel.Rd
@@ -7,7 +7,7 @@
 cancel(future, ...)
 }
 \arguments{
-\item{future}{CivisFuture object to be cancelled.}
+\item{future}{CivisFuture object.}
 
 \item{...}{unused for CivisFuture.}
 }


### PR DESCRIPTION
This adds the table utilities and `CivisFuture` generics to the docs. I checked `NAMESPACE`, and this should be all that we are exporting (except for DBI).

<img width="803" alt="screen shot 2018-05-22 at 2 37 50 pm" src="https://user-images.githubusercontent.com/427445/40385917-d0b19334-5dcd-11e8-9b31-3d669c0eba76.png">
<img width="791" alt="screen shot 2018-05-22 at 2 37 56 pm" src="https://user-images.githubusercontent.com/427445/40385918-d0c3ec1e-5dcd-11e8-8b22-46b0540bb82e.png">

Closes #117 