### PR TITLE
TST fix tests for ggplot2.3

### DIFF
--- a/tests/testthat/test_civis_ml_plot.R
+++ b/tests/testthat/test_civis_ml_plot.R
@@ -17,7 +17,7 @@ test_that("decile plot for classification is produced", {
   expect_true(all(sapply(ps, plot_has_bars)))
 
   plot_has_x_decile <- function(p) {
-    all(p$data[[as.character(p$mapping$x)]] %in% 1:10)
+    all(p$data[["decile"]] %in% 1:10)
   }
   expect_true(all(sapply(ps, plot_has_x_decile)))
 })
@@ -45,9 +45,8 @@ test_that("y_yhat plot for reg is produced", {
   expect_true(all(sapply(ps, plot_has_bins)))
 
   plot_vals_correct <- function(p, m) {
-    var_name <- as.character(p$mapping$fill)
     all.equal(c(m$metrics$metrics$y_yhat_plot$values),
-              p$data[[var_name]])
+              p$data[["values"]])
   }
   ms <- plotable_mods[!is_classif]
   expect_true(all(mapply(plot_vals_correct, ps, ms), fill = T))


### PR DESCRIPTION
`ggplot2` version 2.3.0 now returns quosures for referring to variable names, breaking our tests (but not the code).

Instead of evaluating a quosure I just use the names in the data as given in the implementation. If the names of the data frame used in the implementation of the plotting methods change, the tests would need to change.  It's probably not worth making the tests robust to these changes.

Fixes #118 