### PR TITLE
[RCL-212] FIX: read_civis does not read from textConnections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.5.0] - Unreleased
+
+### Fixed
+- `read_civis` now correctly reads exports from Redshift containing null values.
+
 ## [1.4.0] - 2018-05-04
 
 ### Changed

--- a/tests/testthat/test_io.R
+++ b/tests/testthat/test_io.R
@@ -3,40 +3,7 @@ context("io")
 
 # read_civis ------------------------------------------------------------------
 
-test_that("read_civis reads < 2gb files from memory", {
-  mock_df_string <- "a,b\n1,sentimental\n2,centipede"
-  con <- textConnection(mock_df_string)
-  mock_df <- read.csv(con)
-  close(con)
-  rm(con)
-  mock_sql_job <- function(...) list(script_id = 1337, run_id = 007)
-  mock_GET_result <- function(...) {
-
-    GET_result <- list("url" = "http://www.fakeurl.com",
-                       "headers" = list("Content-Type" = "text/csv"),
-                       "content" = charToRaw(mock_df_string))
-    class(GET_result) <- "response"
-    return(GET_result)
-  }
-  mock_get_sql_runs <- function(...) {
-    list(state = "succeeded",
-         output = list(list(fileId = 1234))
-    )
-  }
-  with_mock(
-    `civis::start_scripted_sql_job` = mock_sql_job,
-    `civis::scripts_post_sql_runs` = function(...) list(id = 1001),
-    `civis::scripts_get_sql_runs` = mock_get_sql_runs,
-    `civis::files_get` = function(...) list(fileSize = 10),
-    `civis::download_script_results` = mock_GET_result,
-    `civis::stop_for_status` = function(...) return(TRUE),
-    expect_equal(mock_df, read_civis(x = "lazy", database = "jellyfish")),
-    expect_equal(mock_df, read_civis(dbplyr::sql("SELECT * FROM lazy"),
-                                     database = "jellyfish"))
-  )
-})
-
-test_that("read_civis.sql reads > 2gb files from file", {
+test_that("read_civis.sql reads csvs", {
   mock_df <- data.frame(a = 1:2, b = c("sentimental", "centipede"))
   mock_get_sql_runs <- function(...) {
     list(state = "succeeded",


### PR DESCRIPTION
This fixes the error from the ticket RCL-212, where Redshift sends out nulls. This may be a bug in `httr`, but in any case, I think it's better to just revert back to downloading redshift csv exports to a temporary file.

The ticket shows a reproducible example (that I won't repeat here for security reasons). On this branch, the call to `read_civis` now works just like `download_civis` would, reading in a data frame with hundreds of rows and the following warnings:

```
Warning messages:
1: In read.table(file = file, header = header, sep = sep, quote = quote,  :
  line 2 appears to contain embedded nulls
2: In read.table(file = file, header = header, sep = sep, quote = quote,  :
  line 3 appears to contain embedded nulls
3: In read.table(file = file, header = header, sep = sep, quote = quote,  :
  line 4 appears to contain embedded nulls
4: In read.table(file = file, header = header, sep = sep, quote = quote,  :
  line 5 appears to contain embedded nulls
5: In scan(file = file, what = what, sep = sep, quote = quote, dec = dec,  :
  embedded nul(s) found in input
```