### PR TITLE
[RCL-106] Retry uploads in write_civis_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [1.5.0] - Unreleased
 
+### Changed
+- `write_civis_file` automatically retries on upload failures.
+
 ### Fixed
 - `read_civis` now correctly reads exports from Redshift containing null values.
 

--- a/R/io.R
+++ b/R/io.R
@@ -331,7 +331,7 @@ write_civis_file.character <- function(x, name = x, expires_at = NULL, ...) {
     u <- files_post(name = name, expires_at = expires_at)
     uploadFields <- u$uploadFields
     uploadFields$file <- httr::upload_file(x)
-    resp <- httr::POST(u$uploadUrl, body = uploadFields)
+    resp <- httr::RETRY("POST", url = u$uploadUrl, body = uploadFields)
     httr::stop_for_status(resp, task = "upload file to S3")
     id <- u$id
   }

--- a/tests/testthat/test_io.R
+++ b/tests/testthat/test_io.R
@@ -178,7 +178,7 @@ test_that("write_civis_file.character returns a file id", {
   with_mock(
     `civis::files_post` = function(...) list(uploadFields = list("fakeurl.com"), id = 5),
     `httr::upload_file` = function(...) "the file",
-    `httr::POST` = function(...) structure(list(status_code = 200), class = "response"),
+    `httr::RETRY` = function(...) structure(list(status_code = 200), class = "response"),
      expect_equal(write_civis_file("mockfile.txt", name = "mockfile.txt"), 5)
   )
   unlink("mockfile.txt")
@@ -189,7 +189,7 @@ test_that("write_civis_file.default returns a file id", {
   with_mock(
     `civis::files_post` = function(...) list(uploadFields = list("fakeurl.com"), id = 5),
     `httr::upload_file` = function(...) "the file",
-    `httr::POST` = function(...) structure(list(status_code = 200), class = "response"),
+    `httr::RETRY` = function(...) structure(list(status_code = 200), class = "response"),
     expect_equal(write_civis_file(mock_df), 5),
     expect_equal(write_civis_file(as.list(mock_df)), 5),
     expect_equal(write_civis_file(1:3), 5)


### PR DESCRIPTION
I've been noticing an above average number of upload failures in my jobs in `write_civis_file`. This should help the client be more robust by default.

I was initially concerned about automatically retrying on `POST`, but retries are best practice according to [the docs](https://docs.aws.amazon.com/AmazonS3/latest/dev/ErrorBestPractices.html) and also happen in [the python client](https://github.com/civisanalytics/civis-python/blob/master/civis/io/_files.py#L100). 

Additionally, should a `POST` successfully complete multiple times, the end result would be that the file is just uploaded multiple times with the last upload overwriting anything previous. It only wastes network bandwidth and does not result in any data corruption.