### PR TITLE
FIX: hyperband now supported with stacking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.5.1] - Unreleased
+
+### Changed
+
+- Hyperband is now supported for stacking estimators in `civis_ml`. Fixes #131.
+
 ## [1.5.0] - 2018-05-20
 
 ### Changed

--- a/R/civis_ml.R
+++ b/R/civis_ml.R
@@ -590,8 +590,7 @@ create_and_run_model <- function(file_id = NULL,
 
   if (!is.null(cross_validation_parameters)) {
     hyperband <- identical(cross_validation_parameters, "hyperband")
-    hyperband_not_supported <- model_type %in% c("sparse_logistic", "sparse_linear_regressor",
-                                                 "stacking_regressor")
+    hyperband_not_supported <- model_type %in% c("sparse_logistic", "sparse_linear_regressor")
     if (hyperband & hyperband_not_supported) {
       stop(paste0("cross_validation_parameters = \"hyperband\" not supported for ", model_type))
     }


### PR DESCRIPTION
We tried to be helpful and fail early with a helpful error message for models where hyperband isn't supported. Since hyperband is now supported for `stacking` estimators, we can remove the error.

Is multi-output still not supported for these?

c("sparse_linear_regressor", "sparse_ridge_regressor",
                          "gradient_boosting_regressor",
                          "sparse_logistic", "gradient_boosting_classifier")

Fixes #131