### PR TITLE
ENH: move devtools to suggests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## [1.5.1] - Unreleased
+## [1.6.0] - Unreleased
 
 ### Changed
 
 - Hyperband is now supported for stacking estimators in `civis_ml`. Fixes #131.
+- `devtools` is no longer a required dependency, but `roxygen2 (> 6.1.0)` is. Fixes #99.
 
 ### Fixed
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ Imports:
     DBI,
     dplyr (>= 0.7.0),
     dbplyr (>= 1.0.0),
-    devtools,
     feather,
     future (>= 1.6.1),
     ggplot2,
@@ -33,12 +32,13 @@ Imports:
     methods,
     memoise,
     purrr,
-    roxygen2,
+    roxygen2 (>= 6.1.0),
     stats,
     stringr,
     testthat,
     utils
 Suggests:
+    devtools,
     knitr,
     rmarkdown,
     mockery,

--- a/R/generate_client.R
+++ b/R/generate_client.R
@@ -14,7 +14,7 @@ fetch_and_generate_client <- function() {
     client_str <- generate_client(spec)
     message(paste0("Writing API to ", FILENAME))
     write_client(client_str, FILENAME = FILENAME)
-    devtools::document()
+    roxygen2::roxygenize(".")
   } else {
     message("Skipping client generation")
   }


### PR DESCRIPTION
This moves the `devtools` to suggests because of the update to `roxygen2 6.1.0`. `roxygen2` now imports `pkgload`, which is now available on CRAN.

Moving `devtools` to suggests makes the package easier to install because devtools has it's own `git` related dependencies that we don't need.