### PR TITLE
Improves write_civis by adding credential_id, headers, and import_arg…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 # Changelog
 
-## [1.6.0] - 2018-08-28
-
-### Added
-- `coef.civis_ml` which returns `civis_ml` model coefficients in the format of `stats::coef`
-- added tests for `coef.civis_ml`
-
 ## Unreleased
 
-### Changed
+### Fixed
+- `write_civis.numeric` now correctly syncs with headers [#150].
 
+### Added
+- `write_civis` gains `header`, `credential_id` and `import_args` arguments to more 
+flexibly import data ([#150, #149, #130]).
+- `coef.civis_ml` which returns `civis_ml` model coefficients in the format of `stats::coef`
+- added tests for `coef.civis_ml`
 - Added `get_feature_importance` to civis_ml_utils
 - Added tests for `get_feature_importance` to test_civis_ml_utils
 - Added `feature_importances.rds` to tests/testthat/data

--- a/man/CivisFuture.Rd
+++ b/man/CivisFuture.Rd
@@ -27,21 +27,19 @@ CivisFuture(expr = NULL, envir = parent.frame(), substitute = FALSE,
 \method{fetch_logs}{CivisFuture}(object, ...)
 }
 \arguments{
-\item{expr}{An \R \link[base]{expression}.}
+\item{expr}{An R \link[base]{expression}.}
 
-\item{envir}{The \link{environment} from where global objects should be
-identified.}
+\item{envir}{The \link{environment} in which the evaluation
+is done (or inherits from if \code{local} is TRUE).}
 
 \item{substitute}{If TRUE, argument \code{expr} is
 \code{\link[base]{substitute}()}:ed, otherwise not.}
 
-\item{globals}{(optional) a logical, a character vector, or a named list
-to control how globals are handled.
-For details, see section 'Globals used by future expressions'
-in the help for \code{\link{future}()}.}
+\item{globals}{(optional) a named list of global objects needed in order
+for the future to be resolved correctly.}
 
 \item{packages}{(optional) a character vector specifying packages
-to be attached in the \R environment evaluating the future.}
+to be attached in the R environment evaluating the future.}
 
 \item{lazy}{If \code{FALSE} (default), the future is resolved
 eagerly (starting immediately), otherwise not.}
@@ -55,10 +53,11 @@ evaluating the future.}
 evaluated the future) after the value of the future is collected.
 \emph{Some types of futures ignore this argument.}}
 
-\item{earlySignal}{Specified whether conditions should be signaled as soon
-as possible or not.}
+\item{earlySignal}{Specified whether conditions should be signaled
+as soon as possible or not.}
 
-\item{label}{An optional character string label attached to the future.}
+\item{label}{An optional character string label attached to the
+future.}
 
 \item{required_resources}{resources, see \code{\link{scripts_post_containers}}}
 

--- a/man/write_civis.Rd
+++ b/man/write_civis.Rd
@@ -12,17 +12,20 @@ write_civis(x, ...)
 \method{write_civis}{data.frame}(x, tablename, database = NULL,
   if_exists = "fail", distkey = NULL, sortkey1 = NULL,
   sortkey2 = NULL, max_errors = NULL, verbose = FALSE,
-  hidden = TRUE, diststyle = NULL, ...)
+  hidden = TRUE, diststyle = NULL, header = TRUE,
+  credential_id = NULL, import_args = NULL, ...)
 
 \method{write_civis}{character}(x, tablename, database = NULL,
   if_exists = "fail", distkey = NULL, sortkey1 = NULL,
   sortkey2 = NULL, max_errors = NULL, verbose = FALSE,
-  hidden = TRUE, diststyle = NULL, ...)
+  hidden = TRUE, diststyle = NULL, header = TRUE,
+  credential_id = NULL, import_args = NULL, ...)
 
 \method{write_civis}{numeric}(x, tablename, database = NULL,
   if_exists = "fail", distkey = NULL, sortkey1 = NULL,
   sortkey2 = NULL, max_errors = NULL, verbose = FALSE,
-  delimiter = ",", hidden = TRUE, diststyle = NULL, ...)
+  delimiter = ",", hidden = TRUE, diststyle = NULL, header = TRUE,
+  credential_id = NULL, import_args = NULL, ...)
 }
 \arguments{
 \item{x}{data frame, file path of a csv, or the id of a csv file on S3 to upload to platform.}
@@ -52,6 +55,14 @@ to remove before failing.}
 \item{hidden}{bool, if \code{TRUE} (default), this job will not appear in the Civis UI.}
 
 \item{diststyle}{string optional. The diststyle to use for the table. One of "even", "all", or "key".}
+
+\item{header}{bool, if \code{TRUE} (default) the first row is a header.}
+
+\item{credential_id}{integer, the id of the credential to be used when performing
+the database import. If \code{NULL} (default), the default credential of the
+current user will be used.}
+
+\item{import_args}{list of additional arguments for \code{\link{imports_post_files}}.}
 
 \item{delimiter}{string, optional. Which delimiter to use. One of
 \code{','}, \code{'\\t'} or \code{'|'}.}
@@ -83,9 +94,12 @@ write_civis(df, "schema.my_table", "my_database")
 # Create new table, append if already exists
 write_civis(df, "schema.my_table", "my_database", if_exists="append")
 
-# Create new table with defined diskey / sortkeys for speed
-write_civis(df, "schema.my_table", "my_database", distkey="id",
-            sortkey1="added_date")
+# Create new table with additional options
+write_civis(df, "schema.my_table", "my_database",
+            distkey="id",
+            sortkey1="added_date",
+            credential_id = 1,
+            header = FALSE)
 
 # Create new table directly from a saved csv
 write_civis("my/file/path.csv", "schema.my_table", "my_database")

--- a/tests/testthat/test_io.R
+++ b/tests/testthat/test_io.R
@@ -100,6 +100,7 @@ test_that("write_civis.data.frame returns meta data if successful", {
     `civis::start_import_job` = function(...) {
       list(uploadUri = "fake", id = 1)
     },
+    `civis::default_credential` = function(...) 1,
     `civis::tables_post_refresh` = function(id) "",
     `httr::PUT` = function(...) list(status_code = 200),
     `civis::imports_post_files_runs` = function(...) list(""),

--- a/tools/integration_tests/smoke_test.R
+++ b/tools/integration_tests/smoke_test.R
@@ -44,12 +44,14 @@ test_that("write_civis writes to redshift", {
   # write_civis.numeric
   tablename <- paste0("scratch.r_smoke_test", sample(1:10000, 1))
   fname <- tempfile(fileext = ".csv")
-  write.csv(iris, file = fname, row.names = FALSE)
+  write.csv(iris, file = fname, row.names = TRUE)
   fid <- write_civis_file(fname, "iris.csv")
   write_civis(fid, tablename, "redshift-general", if_exists = "drop", verbose = TRUE)
   x <- read_civis(tablename)
+  id <- x[,1]
+  x$column_0 <- NULL
   colnames(x) <- colnames(iris)
-  expect_equivalent(x[order(x$id), ], iris)
+  expect_equivalent(x[order(id), ], iris)
   query_civis(paste0("DROP TABLE IF EXISTS ", tablename), database = database)
 })
 


### PR DESCRIPTION
Ehance `write_civis` by adding three arguments: `header`, `credential_id`, and `import_args`. This makes no breaking changes, and addresses #150, #149, #130.

While I would prefer not to add arguments, here are the reasons why I added each:

* `header` - Added for equivalence to the python client. Can easily remove though.

* `import_args` - Additional arguments that could possibly be added in the future for `imports_post_files` and `advancedOptions` in `imports_post_syncs`. 

* `credential_id` - While I originally thought that credentials could be passed using `import_args`, it was confusing to read because `write_civis.character` and `write_civis.numeric` use different importing strategies. `write_civis.character` can use `imports_post_files`, which is a convenience for the more generic `imports_post -> imports_post_syncs` that is used in `write_civis.numeric`. Since `credential_id` is an argument to `imports_post`, and an argument to `imports_post_files`, I thought it was less confusing to for `credential_id` to just be a separate argument to `write_civis` rather than passing it in `import_args`. 

