### PR TITLE
Make verb names in API calls upper case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - `write_civis.numeric` now correctly syncs with headers [#150].
+- Use upper case for REST verb names. [#153].
 
 ### Added
 - `write_civis` gains `header`, `credential_id` and `import_args` arguments to more 

--- a/R/generate_client.R
+++ b/R/generate_client.R
@@ -77,7 +77,7 @@ build_function_body <- function(verb, verb_name, path_name, params) {
     "  path_params  <- path_params[match_params(path_params, args)]\n",
     "  query_params <- query_params[match_params(query_params, args)]\n",
     "  body_params  <- body_params[match_params(body_params, args)]\n",
-    "  resp <- call_api(\"", verb_name, "\", path, path_params, query_params, body_params)\n\n",
+    "  resp <- call_api(\"", toupper(verb_name), "\", path, path_params, query_params, body_params)\n\n",
     "  return(resp)\n\n }\n"
   )
 }

--- a/tests/testthat/test_autogen.R
+++ b/tests/testthat/test_autogen.R
@@ -124,7 +124,7 @@ test_that("build_function_body", {
   expect_true(stringr::str_detect(path, ex_path_names[[1]]))
   expect_true(stringr::str_detect(grep("body_params", body_lines, value = TRUE)[1],
                                   "hostName = host_name"))
-  check_call <- paste0("  resp <- call_api(\"", ex_verb_names[[1]], "\", ",
+  check_call <- paste0("  resp <- call_api(\"", toupper(ex_verb_names[[1]]), "\", ",
                        "path, path_params, query_params, body_params)")
   expect_equal(grep("resp <- ", body_lines, value = TRUE), check_call)
 })


### PR DESCRIPTION
This forces verb names in API calls to be upper case. The only changes are in the first commit, the second commit is regenerating the default specification for testing.

Fixes #153.