### PR TITLE
Partial: Adding second argument to `await_all`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Suggests:
     R.utils,
     rstudioapi,
     yaml
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1
 VignetteBuilder: knitr
 Collate:
     'await.R'

--- a/R/await.R
+++ b/R/await.R
@@ -119,13 +119,19 @@ await_all <- function(f, .x, .y = NULL, ...,
                       .timeout = NULL, .interval = NULL,
                       .verbose = FALSE) {
 
+
   responses <- vector(mode = "list", length = length(.x))
   called <- rep(FALSE, length(.x))
   i <- 1
   start <- Sys.time()
   fname <- as.character(substitute(f))
 
-  zipped_parameters <- if (is.null(.y)) .x else as.list(paste(.x, .y))
+  if (!is.null(.y) & (length(.x) != length(.y))) {
+    error <- c("Lengths of input parameters (.x and .y) are not equal!")
+    stop(error)
+  }
+
+  zipped_parameters <- if (is.null(.y)) .x else lapply(strsplit(paste(.x, .y), ' '), as.integer)
 
   repeat {
     responses[!called] <- lapply(zipped_parameters[!called], safe_call_once,

--- a/R/await.R
+++ b/R/await.R
@@ -111,7 +111,7 @@ await <- function(f, ...,
 #' @param .x a vector of values to be passed to \code{f}
 #' @export
 #' @describeIn await Call a function repeatedly for all values of a vector until all have reached a completed status
-await_all <- function(f, .x, ...,
+await_all <- function(f, .x, .y = NULL, ...,
                       .status_key = "state",
                       .success_states = c("succeeded", "success"),
                       .error_states = c("failed", "cancelled"),
@@ -125,7 +125,7 @@ await_all <- function(f, .x, ...,
   fname <- as.character(substitute(f))
 
   repeat {
-    responses[!called] <- lapply(.x[!called], safe_call_once,
+    responses[!called] <- mapply(safe_call_once, .x[!called], .y[!called],
                                  f = f, ..., .status_key = .status_key,
                                  .success_states = .success_states,
                                  .error_states = .error_states,

--- a/R/await.R
+++ b/R/await.R
@@ -131,7 +131,6 @@ await_all <- function(f, .x, .y = NULL, ...,
     stop(error)
   }
 
-  # zipped_parameters <- if (is.null(.y)) .x else lapply(strsplit(paste(.x, .y), ' '), as.integer)
   zipped_parameters <- if (is.null(.y)) .x else mapply(c, .x, .y, SIMPLIFY=FALSE)
 
   repeat {

--- a/R/await.R
+++ b/R/await.R
@@ -135,10 +135,10 @@ await_all <- function(f, .x, .y = NULL, ...,
 
   repeat {
     responses[!called] <- lapply(zipped_parameters[!called], safe_call_once,
-                                   f = f, ..., .status_key = .status_key,
-                                   .success_states = .success_states,
-                                   .error_states = .error_states,
-                                   fname = fname)
+                                 f = f, ..., .status_key = .status_key,
+                                 .success_states = .success_states,
+                                 .error_states = .error_states,
+                                 fname = fname)
 
     called <- unlist(lapply(responses, function(x) x$called))
 

--- a/R/await.R
+++ b/R/await.R
@@ -109,9 +109,10 @@ await <- function(f, ...,
 }
 
 #' @param .x a vector of values to be passed to \code{f}
+#' @param .y a vector of values to be passed to \code{f} (default \code{NULL})
 #' @export
 #' @describeIn await Call a function repeatedly for all values of a vector until all have reached a completed status
-await_all <- function(f, .x, .y = NULL, ...,
+await_all <- function(f, .x, .y = 0, ...,
                       .status_key = "state",
                       .success_states = c("succeeded", "success"),
                       .error_states = c("failed", "cancelled"),
@@ -141,8 +142,9 @@ await_all <- function(f, .x, .y = NULL, ...,
     if (!is.null(.timeout)) {
       running_time <- as.numeric(difftime(Sys.time(), start, units = "secs"))
       if (running_time > .timeout) {
-        args <- c(list(.x), list(...))
+        args <- c(list(.x), list(.y), list(...))
         names(args)[1] <- names(formals(f))[1]
+        names(args)[2] <- names(formals(f))[2]
         status <- unlist(lapply(responses, function(x) get_status(x$response)))
         stop(civis_timeout_error(fname, args, status))
       }

--- a/R/await.R
+++ b/R/await.R
@@ -131,7 +131,8 @@ await_all <- function(f, .x, .y = NULL, ...,
     stop(error)
   }
 
-  zipped_parameters <- if (is.null(.y)) .x else lapply(strsplit(paste(.x, .y), ' '), as.integer)
+  # zipped_parameters <- if (is.null(.y)) .x else lapply(strsplit(paste(.x, .y), ' '), as.integer)
+  zipped_parameters <- if (is.null(.y)) .x else mapply(c, .x, .y, SIMPLIFY=FALSE)
 
   repeat {
     responses[!called] <- lapply(zipped_parameters[!called], safe_call_once,
@@ -288,8 +289,3 @@ await_err_msg <- function(fname, args = NULL, error = NULL) {
   arg_str  <- if (!is.null(args)) paste0(names(args), " = ", args, collapse = ", ")
   paste0(fname, "(", arg_str, "): ", error)
 }
-
-
-
-
-

--- a/man/CivisFuture.Rd
+++ b/man/CivisFuture.Rd
@@ -27,19 +27,21 @@ CivisFuture(expr = NULL, envir = parent.frame(), substitute = FALSE,
 \method{fetch_logs}{CivisFuture}(object, ...)
 }
 \arguments{
-\item{expr}{An R \link[base]{expression}.}
+\item{expr}{An \R \link[base]{expression}.}
 
-\item{envir}{The \link{environment} in which the evaluation
-is done (or inherits from if \code{local} is TRUE).}
+\item{envir}{The \link{environment} from where global objects should be
+identified.}
 
 \item{substitute}{If TRUE, argument \code{expr} is
 \code{\link[base]{substitute}()}:ed, otherwise not.}
 
-\item{globals}{(optional) a named list of global objects needed in order
-for the future to be resolved correctly.}
+\item{globals}{(optional) a logical, a character vector, or a named list
+to control how globals are handled.
+For details, see section 'Globals used by future expressions'
+in the help for \code{\link{future}()}.}
 
 \item{packages}{(optional) a character vector specifying packages
-to be attached in the R environment evaluating the future.}
+to be attached in the \R environment evaluating the future.}
 
 \item{lazy}{If \code{FALSE} (default), the future is resolved
 eagerly (starting immediately), otherwise not.}
@@ -50,14 +52,16 @@ the assignments are done to the global environment of the \R process
 evaluating the future.}
 
 \item{gc}{If TRUE, the garbage collector run (in the process that
-evaluated the future) after the value of the future is collected.
+evaluated the future) only after the value of the future is collected.
+Exactly when the values are collected may depend on various factors such
+as number of free workers and whether \code{earlySignal} is TRUE (more
+frequently) or FALSE (less frequently).
 \emph{Some types of futures ignore this argument.}}
 
-\item{earlySignal}{Specified whether conditions should be signaled
-as soon as possible or not.}
+\item{earlySignal}{Specified whether conditions should be signaled as soon
+as possible or not.}
 
-\item{label}{An optional character string label attached to the
-future.}
+\item{label}{An optional character string label attached to the future.}
 
 \item{required_resources}{resources, see \code{\link{scripts_post_containers}}}
 

--- a/tests/testthat/test_await.R
+++ b/tests/testthat/test_await.R
@@ -169,13 +169,13 @@ test_that("await_all calls f until completion", {
   fake_f <- mockery::mock(list(status = "running"),
                  list(status = "running"),
                  list(status = "succeeded"), cycle = TRUE)
-  await_all(fake_f, .x = 1:2, .y = 1:2, .status_key = "status", .interval = .001)
+  await_all(fake_f, .x = 1:2, .y = 3:4, .status_key = "status", .interval = .001)
   mockery::expect_called(fake_f, 6)
 })
 
 test_that("await_all returns list of completed responses", {
   set.seed(2)
-  x <- await_all(f_rand, .x = 1:2, .y = 1:2, job_id = 1)
+  x <- await_all(f_rand, .x = 1:2, .y = 3:4, job_id = 1)
   expect_is(x, "list")
   expect_equal(sapply(x, get_status), rep("succeeded", 2))
   expect_equal(sapply(x, function(x) x$id), 1:2)
@@ -183,14 +183,14 @@ test_that("await_all returns list of completed responses", {
 })
 
 test_that("await_all vectorizes over any argument", {
-  x <- await_all(f_rand, .x = 1:2, .y = 1:2, id = 1)
+  x <- await_all(f_rand, .x = 1:2, .y = 3:4, id = 1)
   expect_equal(sapply(x, function(x) x$job_id), 1:2)
   expect_equal(sapply(x, function(x) x$run_id), 1:2)
 })
 
 test_that("await_all catches arbitrary status and keys", {
   f <- function(x) list(party_status = "going home", value = x)
-  x <- await_all(f, .x = 1:2, .y = 1:2, .status_key = "party_status",
+  x <- await_all(f, .x = 1:2, .y = 3:4, .status_key = "party_status",
                  .success_states = "going home", .verbose = TRUE)
   expect_equal(sapply(x, get_status), rep("going home", 2))
   expect_equal(sapply(x, function(x) x$value), 1:2)
@@ -199,14 +199,14 @@ test_that("await_all catches arbitrary status and keys", {
 test_that("await_all throws civis_timeout_error", {
   f <- function(x) list(state = "at the party")
   msg <- c("Timeout exceeded. Current status: at the party, at the party")
-  expect_error(await_all(f, .x = 1:2, .y = 1:2, .timeout = .002, .interval = .001), msg)
+  expect_error(await_all(f, .x = 1:2, .y = 3:4, .timeout = .002, .interval = .001), msg)
 
-  e <- tryCatch(await_all(f, .x = 1:2, .y = 1:2, .timeout = .002, .interval = .001),
+  e <- tryCatch(await_all(f, .x = 1:2, .y = 3:4, .timeout = .002, .interval = .001),
            "civis_timeout_error" = function(e) e)
 
   get_error(e)
 
-  e2 <- tryCatch(await_all(f, .x = 1:2, .y = 1:2, .timeout = .002, .interval = .001),
+  e2 <- tryCatch(await_all(f, .x = 1:2, .y = 3:4, .timeout = .002, .interval = .001),
                 "civis_error" = function(e) e)
   expect_equal(e, e2)
 })
@@ -217,7 +217,7 @@ test_that("await_all catches mixed failure states", {
            list(state = "failed", error = "platform error"),
            list(state = "succeeded"))
   }
-  r <- await_all(f, .x = 1:3, .y = 1:2)
+  r <- await_all(f, .x = 1:3, .y = 3:4)
   expect_true(is.civis_error(r[[2]]))
   expect_equal(get_error(r[[2]])$error, "platform error")
   expect_equal(get_error(r[[2]])$args, list(x = 2))
@@ -225,7 +225,13 @@ test_that("await_all catches mixed failure states", {
 
 test_that("await_all verbose prints all tasks and status", {
   set.seed(2)
-  msgs <- capture_messages(await_all(f_rand, .x = 1:5, .y = 1:2, job_id = 1, .verbose = TRUE))
+  msgs <- capture_messages(await_all(f_rand, .x = 1:5, .y = 3:4, job_id = 1, .verbose = TRUE))
   expect_true(any(grepl("partying instead", x = msgs)))
   expect_equal(length(msgs), 5)
 })
+
+test_that("await_all throws an error if lengths of .x and .y differ", {
+
+})
+
+

--- a/tests/testthat/test_await.R
+++ b/tests/testthat/test_await.R
@@ -156,22 +156,22 @@ test_that("safe_call_once catches civis_await_error", {
   expect_is(e, c("civis_await_error", "civis_error", "error"))
 })
 
-f_rand <- function(id, job_id) {
+
+
+
+
+
+
+
+
+f_rand <- function(id, run_id, job_id) {
   x <- runif(1)
   if (x < .9) {
-    return(list(state = "succeeded", id = id, job_id = job_id))
+    return(list(state = "succeeded", id = id, run_id = run_id, job_id = job_id))
   } else {
-    return(list(state = "partying instead", id = id, job_id = job_id))
+    return(list(state = "partying instead", id = id, run_id = run_id, job_id = job_id))
   }
 }
-
-
-
-
-
-
-
-
 
 test_that("await_all calls f until completion", {
   fake_f <- mockery::mock(list(status = "running"),
@@ -183,7 +183,7 @@ test_that("await_all calls f until completion", {
 
 test_that("await_all returns list of completed responses", {
   set.seed(2)
-  x <- await_all(f_rand, .x = 1:2, job_id = 1)
+  x <- await_all(f_rand, .x = 1:2, .y = 1:2, job_id = 1)
   expect_is(x, "list")
   expect_equal(sapply(x, get_status), rep("succeeded", 2))
   expect_equal(sapply(x, function(x) x$id), 1:2)
@@ -193,6 +193,7 @@ test_that("await_all returns list of completed responses", {
 test_that("await_all vectorizes over any argument", {
   x <- await_all(f_rand, .x = 1:2, .y = 1:2, id = 1)
   expect_equal(sapply(x, function(x) x$job_id), 1:2)
+  expect_equal(sapply(x, function(x) x$run_id), 1:2)
 })
 
 test_that("await_all catches arbitrary status and keys", {

--- a/tests/testthat/test_await.R
+++ b/tests/testthat/test_await.R
@@ -165,11 +165,19 @@ f_rand <- function(id, job_id) {
   }
 }
 
+
+
+
+
+
+
+
+
 test_that("await_all calls f until completion", {
   fake_f <- mockery::mock(list(status = "running"),
                  list(status = "running"),
                  list(status = "succeeded"), cycle = TRUE)
-  await_all(fake_f, 1:2, .status_key = "status", .interval = .001)
+  await_all(fake_f, .x = 1:2, .y = 1:2, .status_key = "status", .interval = .001)
   mockery::expect_called(fake_f, 6)
 })
 
@@ -183,13 +191,13 @@ test_that("await_all returns list of completed responses", {
 })
 
 test_that("await_all vectorizes over any argument", {
-  x <- await_all(f_rand, .x = 1:2, id = 1)
+  x <- await_all(f_rand, .x = 1:2, .y = 1:2, id = 1)
   expect_equal(sapply(x, function(x) x$job_id), 1:2)
 })
 
 test_that("await_all catches arbitrary status and keys", {
   f <- function(x) list(party_status = "going home", value = x)
-  x <- await_all(f, .x = 1:2,  .status_key = "party_status",
+  x <- await_all(f, .x = 1:2, .y = 1:2, .status_key = "party_status",
                  .success_states = "going home", .verbose = TRUE)
   expect_equal(sapply(x, get_status), rep("going home", 2))
   expect_equal(sapply(x, function(x) x$value), 1:2)
@@ -198,14 +206,14 @@ test_that("await_all catches arbitrary status and keys", {
 test_that("await_all throws civis_timeout_error", {
   f <- function(x) list(state = "at the party")
   msg <- c("Timeout exceeded. Current status: at the party, at the party")
-  expect_error(await_all(f, .x = 1:2, .timeout = .002, .interval = .001), msg)
+  expect_error(await_all(f, .x = 1:2, .y = 1:2, .timeout = .002, .interval = .001), msg)
 
-  e <- tryCatch(await_all(f, .x = 1:2, .timeout = .002, .interval = .001),
+  e <- tryCatch(await_all(f, .x = 1:2, .y = 1:2, .timeout = .002, .interval = .001),
            "civis_timeout_error" = function(e) e)
 
   get_error(e)
 
-  e2 <- tryCatch(await_all(f, .x = 1:2, .timeout = .002, .interval = .001),
+  e2 <- tryCatch(await_all(f, .x = 1:2, .y = 1:2, .timeout = .002, .interval = .001),
                 "civis_error" = function(e) e)
   expect_equal(e, e2)
 })
@@ -216,7 +224,7 @@ test_that("await_all catches mixed failure states", {
            list(state = "failed", error = "platform error"),
            list(state = "succeeded"))
   }
-  r <- await_all(f, .x = 1:3)
+  r <- await_all(f, .x = 1:3, .y = 1:2)
   expect_true(is.civis_error(r[[2]]))
   expect_equal(get_error(r[[2]])$error, "platform error")
   expect_equal(get_error(r[[2]])$args, list(x = 2))
@@ -224,7 +232,7 @@ test_that("await_all catches mixed failure states", {
 
 test_that("await_all verbose prints all tasks and status", {
   set.seed(2)
-  msgs <- capture_messages(await_all(f_rand, .x = 1:5, job_id = 1, .verbose = TRUE))
+  msgs <- capture_messages(await_all(f_rand, .x = 1:5, .y = 1:2, job_id = 1, .verbose = TRUE))
   expect_true(any(grepl("partying instead", x = msgs)))
   expect_equal(length(msgs), 5)
 })

--- a/tests/testthat/test_await.R
+++ b/tests/testthat/test_await.R
@@ -165,54 +165,53 @@ f_rand <- function(job_id, ...) {
   }
 }
 
-test_that("await_all calls f until completion", {
+test_that("await_all calls f until completion - univariate", {
   fake_f <- mockery::mock(list(status = "running"),
                  list(status = "running"),
                  list(status = "succeeded"), cycle = TRUE)
-  await_all(fake_f, .x = 1:2, .y = 3:4, .status_key = "status", .interval = .001)
+  await_all(fake_f, 1:2, .status_key = "status", .interval = .001)
   mockery::expect_called(fake_f, 6)
 })
 
-test_that("await_all returns list of completed responses", {
+test_that("await_all returns list of completed responses - univariate", {
   set.seed(2)
-  x <- await_all(f_rand, .x = 1:2, .y = 3:4, job_id = 1)
+  x <- await_all(f_rand, .x = 1:2, job_id = 1)
   expect_is(x, "list")
   expect_equal(sapply(x, get_status), rep("succeeded", 2))
-  expect_equal(sapply(x, function(x) x$args), list(c(1, 3), c(2, 4)))
+  expect_equal(sapply(x, function(x) x$id), 1:2)
   expect_equal(sapply(x, function(x) x$job_id), rep(1, 2))
 })
 
-# test_that("await_all vectorizes over any argument", {
-#   x <- await_all(f_rand, .x = 1:2, .y = 3:4, id = 1)
-#   expect_equal(sapply(x, function(x) x$job_id), 1:2)
-#   expect_equal(sapply(x, function(x) x$run_id), 1:2)
-# })
+test_that("await_all vectorizes over any argument - univariate", {
+  x <- await_all(f_rand, .x = 1:2, id = 1)
+  expect_equal(sapply(x, function(x) x$job_id), 1:2)
+})
 
-test_that("await_all catches arbitrary status and keys", {
-  f <- function(x, y) list(party_status = "going home", value = x)
-  x <- await_all(f, .x = 1:2, .y = 3:4, .status_key = "party_status",
+test_that("await_all catches arbitrary status and keys - univariate", {
+  f <- function(x) list(party_status = "going home", value = x)
+  x <- await_all(f, .x = 1:2,  .status_key = "party_status",
                  .success_states = "going home", .verbose = TRUE)
   expect_equal(sapply(x, get_status), rep("going home", 2))
-  expect_equal(sapply(x, function(x) x$value), cbind(c(1, 3), c(2, 4)))
+  expect_equal(sapply(x, function(x) x$value), 1:2)
 })
 
 test_that("await_all throws civis_timeout_error", {
   f <- function(x) list(state = "at the party")
   msg <- c("Timeout exceeded. Current status: at the party, at the party")
-  expect_error(await_all(f, .x = 1:2, .y = 3:4, .timeout = .002, .interval = .001), msg)
+  expect_error(await_all(f, .x = 1:2, .timeout = .002, .interval = .001), msg)
 
-  e <- tryCatch(await_all(f, .x = 1:2, .y = 3:4, .timeout = .002, .interval = .001),
+  e <- tryCatch(await_all(f, .x = 1:2, .timeout = .002, .interval = .001),
            "civis_timeout_error" = function(e) e)
 
   get_error(e)
 
-  e2 <- tryCatch(await_all(f, .x = 1:2, .y = 3:4, .timeout = .002, .interval = .001),
+  e2 <- tryCatch(await_all(f, .x = 1:2, .timeout = .002, .interval = .001),
                 "civis_error" = function(e) e)
   expect_equal(e, e2)
 })
 
 test_that("await_all catches mixed failure states", {
-  f <- function(x, y) {
+  f <- function(x) {
     switch(x, list(state = "succeeded"),
            list(state = "failed", error = "platform error"),
            list(state = "succeeded"))
@@ -234,4 +233,27 @@ test_that("await_all throws an error if lengths of .x and .y differ", {
   expect_error(await_all(f, .x = 1:2, .y = 3:5))
 })
 
+test_that("await_all calls f until completion - multivariate", {
+  fake_f <- mockery::mock(list(status = "running"),
+                          list(status = "running"),
+                          list(status = "succeeded"), cycle = TRUE)
+  await_all(fake_f, .x = 1:2, .y = 3:4, .status_key = "status", .interval = .001)
+  mockery::expect_called(fake_f, 6)
+})
 
+test_that("await_all returns list of completed responses - multivariate", {
+  set.seed(2)
+  x <- await_all(f_rand, .x = 1:2, .y = 3:4, job_id = 1)
+  expect_is(x, "list")
+  expect_equal(sapply(x, get_status), rep("succeeded", 2))
+  expect_equal(sapply(x, function(x) x$args), list(c(1, 3), c(2, 4)))
+  expect_equal(sapply(x, function(x) x$job_id), rep(1, 2))
+})
+
+test_that("await_all catches arbitrary status and keys - multivariate", {
+  f <- function(x, y) list(party_status = "going home", value = x)
+  x <- await_all(f, .x = 1:2, .y = 3:4, .status_key = "party_status",
+                 .success_states = "going home", .verbose = TRUE)
+  expect_equal(sapply(x, get_status), rep("going home", 2))
+  expect_equal(sapply(x, function(x) x$value), cbind(c(1, 3), c(2, 4)))
+})

--- a/tests/testthat/test_await.R
+++ b/tests/testthat/test_await.R
@@ -178,7 +178,7 @@ test_that("await_all returns list of completed responses - univariate", {
   x <- await_all(f_rand, .x = 1:2, job_id = 1)
   expect_is(x, "list")
   expect_equal(sapply(x, get_status), rep("succeeded", 2))
-  expect_equal(sapply(x, function(x) x$id), 1:2)
+  expect_equal(sapply(x, function(x) unlist(x$args)), 1:2)
   expect_equal(sapply(x, function(x) x$job_id), rep(1, 2))
 })
 

--- a/tests/testthat/test_await.R
+++ b/tests/testthat/test_await.R
@@ -156,12 +156,12 @@ test_that("safe_call_once catches civis_await_error", {
   expect_is(e, c("civis_await_error", "civis_error", "error"))
 })
 
-f_rand <- function(id, run_id, job_id) {
+f_rand <- function(job_id, ...) {
   x <- runif(1)
   if (x < .9) {
-    return(list(state = "succeeded", id = id, run_id = run_id, job_id = job_id))
+    return(list(state = "succeeded", job_id = job_id, args = list(...)))
   } else {
-    return(list(state = "partying instead", id = id, run_id = run_id, job_id = job_id))
+    return(list(state = "partying instead", job_id = job_id, args = list(...)))
   }
 }
 

--- a/tests/testthat/test_await.R
+++ b/tests/testthat/test_await.R
@@ -156,14 +156,6 @@ test_that("safe_call_once catches civis_await_error", {
   expect_is(e, c("civis_await_error", "civis_error", "error"))
 })
 
-
-
-
-
-
-
-
-
 f_rand <- function(id, run_id, job_id) {
   x <- runif(1)
   if (x < .9) {


### PR DESCRIPTION
Fixes #147 ENH: `await_all` should be vectorized over two arguments

Does not pass existing tests, submitting what I have so far for any feedback.  Replacing lapply() with mapply() seems to have broken something.