### PR TITLE
1.6.1

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
+^CRAN-RELEASE$
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^\.travis\.yml$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.6.1] - 2019-02-12
+
+### Fixed
+- Update link in CivisML vignette.
+
 ## [1.6.0] - 2019-02-11
 
 ### Fixed

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: civis
 Title: R Client for the 'Civis data science API'
-Version: 1.6.0
+Version: 1.6.1
 Authors@R: c(
   person("Patrick", "Miller", email = "pmiller@civisanalytics.com", role = c("cre", "aut")),
   person("Keith", "Ingersoll", email = "kingersoll@civisanalytics.com", role = "aut"),
@@ -13,7 +13,7 @@ Authors@R: c(
   person("Elizabeth", "Sander", email = "lsander@civisanalytics.com", role = "ctb"),
   person("Madison", "Hobbs", email = "mhobbs@g.hmc.edu", role = "ctb"),
   person("Anna", "Bladey", email = "abladey@civisanalytics.com", role = "ctb"))
-Description: A set of tools around common workflows and a convenient interface to make
+Description: A convenient interface for making
   requests directly to the 'Civis data science API' <https://www.civisanalytics.com/platform/>.
 Depends:
     R (>= 3.2.0)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,9 +1,11 @@
-The version has been bumped to 1.6.0, adding a few features and fixing an API issue.
+The version has been bumped to 1.6.1, fixing the broken link from the previous 
+submission.
 
 ## Test environments
 * local OS X install, R 3.5.2
 * ubuntu 14.04 (oldrel, release, devel)
-* win-builder (devel)
+* ubuntu 16.04, Fedora Linux
+* win-builder (devel), windows serrver 2008
 
 ## R CMD check results
 There were no ERRORs or WARNINGs.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,10 +1,7 @@
-This is a patch release fixing a CRAN check warning from the new roxygen2 package,
-and the windows build failure on CRAN.
-
-The version has been bumped to 1.5.1.
+The version has been bumped to 1.6.0, adding a few features and fixing an API issue.
 
 ## Test environments
-* local OS X install, R 3.5.1
+* local OS X install, R 3.5.2
 * ubuntu 14.04 (oldrel, release, devel)
 * win-builder (devel)
 

--- a/vignettes/civis_ml.Rmd
+++ b/vignettes/civis_ml.Rmd
@@ -11,7 +11,7 @@ vignette: >
 
 There are so many models to build! When this becomes challenging on a local machine, offloading model building to the cloud can save a lot of time and effort.
 
-[CivisML](https://www.civisanalytics.com/blog/civisml-scikit-learn-at-scale/) is a machine learning service on Civis Platform that makes this as painless as possible. You can fit many different models, do extensive hyperparameter tuning, and score data sets with millions of observations stored in remote databases. Once these models are built, they live in Civis Platform permanently and can be included into production pipelines. Results can be easily incorporated into reports and dashboards.
+[CivisML](https://medium.com/civis-analytics/civisml-scikit-learn-at-scale-b01b496916ea) is a machine learning service on Civis Platform that makes this as painless as possible. You can fit many different models, do extensive hyperparameter tuning, and score data sets with millions of observations stored in remote databases. Once these models are built, they live in Civis Platform permanently and can be included into production pipelines. Results can be easily incorporated into reports and dashboards.
 
 CivisML is built in Python using [scikit-learn](http://scikit-learn.org/stable/), and leverages AWS behind the scenes for efficient distributed computing. However, most of its features can be used through R without knowledge of Python or AWS with the `civis_ml` function in `civis`.
 


### PR DESCRIPTION
A few small fixes requested by the CRAN maintainers.

Changes
- fix broken link in CivisML vignette
- remove false positive misspelling of 'workflows' from package description