### PR TITLE
FIX: serialization compatibility on R 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [1.7.0] - Unreleased
 
+### Fixed
+
+- Docker images for `civis_platform` are now tagged to `civisanalytics/datascience-r:2` for
+compatibility with R 3.6.0.
+
 ### Added
 
 Utitilies for platform  scripts

--- a/R/civis_future.R
+++ b/R/civis_future.R
@@ -69,7 +69,7 @@ CivisFuture <- function(expr = NULL,
                         label = NULL,
                         required_resources = list(cpu = 1024, memory = 2048, diskSpace = 4),
                         docker_image_name = "civisanalytics/datascience-r",
-                        docker_image_tag = "2.3.0",
+                        docker_image_tag = "2",
                          ...) {
 
   gp <- future::getGlobalsAndPackages(expr, envir = envir, globals = globals)


### PR DESCRIPTION
Small change, long story.

The integration tests were failing in `plan(civis_platform)` because they were on R latest. 

The break happened because the serialization format is changing in R 3.6.0, so any `.rds` files generated by R 3.6.0 require at least R 3.5.0 to read. This failed in the `future` test where the `.rds` we upload to platform was generated by R 3.6.0 but read by an older R version prior to R 3.5.0 (e.g. R 3.4.3).

We have R 3.5.2 in datascience-r 2.8.0, so I can just bump the image to fix. I'm tagging the docker image for `plan(civis_platform)` to `2` to decrease errors of this kind in the future.