### PR TITLE
await_all 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- `await_all` is now vectorized over two arguments (typically run and job
+  ids) as intended (#171).
 - Docker images for `civis_platform` are now tagged to `civisanalytics/datascience-r:2` for
 compatibility with R 3.6.0.
 

--- a/R/await.R
+++ b/R/await.R
@@ -112,7 +112,7 @@ await <- function(f, ...,
 }
 
 #' @param .x a vector of values to be passed to \code{f}
-#' @param .y a vector of values to be passed to \code{f}
+#' @param .y a vector of values to be passed to \code{f} (default \code{NULL})
 #' @export
 #' @describeIn await Call a function repeatedly for all values of a vector until all have reached a completed status
 await_all <- function(f, .x, .y = NULL, ...,
@@ -130,7 +130,7 @@ await_all <- function(f, .x, .y = NULL, ...,
   fname <- as.character(substitute(f))
 
   if (!is.null(.y) & (length(.x) != length(.y))) {
-    error <- c("Lengths of input parameters (.x and .y) are not equal")
+    error <- c("Lengths of input parameters (.x and .y) are not equal!")
     stop(error)
   }
 
@@ -178,13 +178,9 @@ await_all <- function(f, .x, .y = NULL, ...,
     }
 
     if (!is.null(.timeout)) {
-      running_time <-
-        as.numeric(difftime(Sys.time(), start, units = "secs"))
+      running_time <- as.numeric(difftime(Sys.time(), start, units = "secs"))
       if (running_time > .timeout) {
-        status <-
-          unlist(lapply(responses, function(x)
-            get_status(x$response)))
-        args <- params[!called]
+        status <- unlist(lapply(responses, function(x) get_status(x$response)))
         stop(civis_timeout_error(fname, args, status))
       }
     }
@@ -194,8 +190,7 @@ await_all <- function(f, .x, .y = NULL, ...,
     if (.verbose) {
       pretty_time <- formatC(interval, digits = 3, format = "fg")
       make_msg <- function(x) {
-        msg <- paste0("Task: ", x,
-                      " Status: ", responses[[x]]$response[[.status_key]],
+        msg <- paste0("Task: ", x, " Status: ", responses[[x]]$response[[.status_key]],
                       " @ ", Sys.time(),
                       ". Retry ", i, " in ", pretty_time, " seconds")
         message(msg)

--- a/R/await.R
+++ b/R/await.R
@@ -38,6 +38,9 @@
 #'    r <- try(await(queries_get, id = q_id))
 #'    get_error(r)
 #'
+#'    jobs <- c(1234, 5678)
+#'    runs <- c(1234, 5678)
+#'    rs <- await_all(scripts_get_r_runs, .x = jobs, .y = runs)
 #' }
 #' @export
 #' @details
@@ -109,7 +112,7 @@ await <- function(f, ...,
 }
 
 #' @param .x a vector of values to be passed to \code{f}
-#' @param .y a vector of values to be passed to \code{f} (default \code{NULL})
+#' @param .y a vector of values to be passed to \code{f}
 #' @export
 #' @describeIn await Call a function repeatedly for all values of a vector until all have reached a completed status
 await_all <- function(f, .x, .y, ...,

--- a/man/CivisFuture.Rd
+++ b/man/CivisFuture.Rd
@@ -14,7 +14,7 @@ CivisFuture(expr = NULL, envir = parent.frame(), substitute = FALSE,
   gc = FALSE, earlySignal = FALSE, label = NULL,
   required_resources = list(cpu = 1024, memory = 2048, diskSpace = 4),
   docker_image_name = "civisanalytics/datascience-r",
-  docker_image_tag = "2.3.0", ...)
+  docker_image_tag = "2", ...)
 
 \method{run}{CivisFuture}(future, ...)
 

--- a/man/await.Rd
+++ b/man/await.Rd
@@ -9,7 +9,7 @@ await(f, ..., .status_key = "state", .success_states = c("succeeded",
   "success"), .error_states = c("failed", "cancelled"),
   .timeout = NULL, .interval = NULL, .verbose = FALSE)
 
-await_all(f, .x, .y, ..., .status_key = "state",
+await_all(f, .x, .y = NULL, ..., .status_key = "state",
   .success_states = c("succeeded", "success"),
   .error_states = c("failed", "cancelled"), .timeout = NULL,
   .interval = NULL, .verbose = FALSE)
@@ -37,7 +37,7 @@ intervals with jitter (see 'Details')}
 
 \item{.x}{a vector of values to be passed to \code{f}}
 
-\item{.y}{a vector of values to be passed to \code{f}}
+\item{.y}{a vector of values to be passed to \code{f} (default \code{NULL})}
 }
 \description{
 \code{await} repeatedly calls a Civis API endpoint such as \code{scripts_get_sql_runs}

--- a/man/await.Rd
+++ b/man/await.Rd
@@ -9,7 +9,7 @@ await(f, ..., .status_key = "state", .success_states = c("succeeded",
   "success"), .error_states = c("failed", "cancelled"),
   .timeout = NULL, .interval = NULL, .verbose = FALSE)
 
-await_all(f, .x, .y = NULL, ..., .status_key = "state",
+await_all(f, .x, .y, ..., .status_key = "state",
   .success_states = c("succeeded", "success"),
   .error_states = c("failed", "cancelled"), .timeout = NULL,
   .interval = NULL, .verbose = FALSE)
@@ -37,7 +37,7 @@ intervals with jitter (see 'Details')}
 
 \item{.x}{a vector of values to be passed to \code{f}}
 
-\item{.y}{a vector of values to be passed to \code{f} (default \code{NULL})}
+\item{.y}{a vector of values to be passed to \code{f}}
 }
 \description{
 \code{await} repeatedly calls a Civis API endpoint such as \code{scripts_get_sql_runs}
@@ -102,6 +102,9 @@ Approximate intervals for a given number of retries are as follows:
    r <- try(await(queries_get, id = q_id))
    get_error(r)
 
+   jobs <- c(1234, 5678)
+   runs <- c(1234, 5678)
+   rs <- await_all(scripts_get_r_runs, .x = jobs, .y = runs)
 }
 }
 \seealso{

--- a/tests/testthat/test_await.R
+++ b/tests/testthat/test_await.R
@@ -196,38 +196,35 @@ test_that("await_all catches arbitrary status and keys - univariate", {
 })
 
 test_that("await_all throws civis_timeout_error", {
-  f <- function(x, y) list(state = "at the party")
+  f <- function(x) list(state = "at the party")
   msg <- c("Timeout exceeded. Current status: at the party, at the party")
-  expect_error(await_all(f, .x = 1:2, .y = 1:2, .timeout = .002,
-                         .interval = .001), msg)
+  expect_error(await_all(f, .x = 1:2, .timeout = .002, .interval = .001), msg)
 
-  e <- tryCatch(await_all(f, .x = 1:2, .y = 1:2, .timeout = .002, .interval = .001),
+  e <- tryCatch(await_all(f, .x = 1:2, .timeout = .002, .interval = .001),
            "civis_timeout_error" = function(e) e)
 
   get_error(e)
 
-  e2 <- tryCatch(await_all(f, .x = 1:2, .y = 1:2, .timeout = .002,
-                           .interval = .001),
+  e2 <- tryCatch(await_all(f, .x = 1:2, .timeout = .002, .interval = .001),
                 "civis_error" = function(e) e)
   expect_equal(e, e2)
 })
 
 test_that("await_all catches mixed failure states", {
-  f <- function(x, y) {
+  f <- function(x) {
     switch(x, list(state = "succeeded"),
            list(state = "failed", error = "platform error"),
            list(state = "succeeded"))
   }
-  r <- await_all(f, .x = 1:2, .y = 1:2)
+  r <- await_all(f, .x = 1:2)
   expect_true(is.civis_error(r[[2]]))
   expect_equal(get_error(r[[2]])$error, "platform error")
-  expect_equal(get_error(r[[2]])$args, list(x = 2, y = 2))
+  expect_equal(get_error(r[[2]])$args, list(x = 2))
 })
 
 test_that("await_all verbose prints all tasks and status", {
   set.seed(2)
-  msgs <- capture_messages(
-    await_all(f_rand, .x = 1:5, .y = 1:5, .verbose = TRUE))
+  msgs <- capture_messages(await_all(f_rand, .x = 1:5, .y = 1:5, .verbose = TRUE))
   expect_true(any(grepl("partying instead", x = msgs)))
   expect_equal(length(msgs), 5)
 })


### PR DESCRIPTION
Here's a fix for `await_all`. It is now vectorized over two arguments, and still works if only given `.x`. `call_once` was refactored to remove an unnecessary `.id` parameter.

```
ids <- c(23820523, 23820523)
runs <- c(130390319, 130390319)
await_all(scripts_get_r_runs, .x = ids, .y = runs)

# produces timeout error
await_all(scripts_get_r_runs, .x = ids, .y = runs, .success_states = 'asdf', .timeout = 1)

# nice logging
await_all(scripts_get_r_runs, .x = ids, .y = runs, .success_states = 'asdf', .verbose = TRUE, .timeout=2)
```
Fixes #171 . @Zephyraith thanks for the 30% WIP to get this started!