### PR TITLE
[SERD-1445] return JSON from run template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- `run_template` takes an additional value of JSONValue. If TRUE,
+  frunction returns the JSON output instead of the fileid.
+
 ## [2.0.0] - 2019-06-19
 
 ### Changed

--- a/R/scripts.R
+++ b/R/scripts.R
@@ -124,7 +124,7 @@ run_template <- function(id, arguments, JSONValue=FALSE, ...) {
 	return()
      }
      if (length(json_output) > 1) {
-        warning("Error in returning JSON outputs of template run -- too many JSON outputs")
+        warning("More than 1 JSON output for template. Returning only the first one")
      }
      return(json_output[[1]]$value)
 

--- a/R/scripts.R
+++ b/R/scripts.R
@@ -93,9 +93,10 @@ run_civis <- function(expr, ...) {
 #' @param ... additional arguments to \code{scripts_post_custom}
 #' @return If JSONValue is FALSE, File ids of any run outputs are returned.
 #'         If JSONValue is TRUE, JSON values of first JSON run output is returned.
-#'           If there are no JSON outputs, nothing is returned
-#'           If there are more than 1 JSON outputs, error message is printed 
-#'             and nothing is returned.
+#'           If there are no JSON outputs, warning message is printed
+#'             and nothing is returned
+#'           If there are more than 1 JSON outputs, warning message is printed 
+#'             and the first JSON output is returned.
 #'                              
 #' @export
 #' @family script_utils

--- a/R/scripts.R
+++ b/R/scripts.R
@@ -109,7 +109,7 @@ run_civis <- function(expr, ...) {
 #' run_template(id, arguments = list(arg1 = 1, arg2 = 2), ...)
 #'
 #' # Run the template and return JSON value outputs
-#' run_template(id, arguments = list(arg1 = 1, arg2 = 2), JSONValue=TRUE...)
+#' run_template(id, arguments = list(arg1 = 1, arg2 = 2), JSONValue=TRUE, ...)
 #' }
 run_template <- function(id, arguments, JSONValue=FALSE, ...) {
   job <- scripts_post_custom(id, arguments = arguments, ...)

--- a/R/scripts.R
+++ b/R/scripts.R
@@ -115,17 +115,19 @@ run_template <- function(id, arguments, JSONValue=FALSE, ...) {
   run <- scripts_post_custom_runs(job$id)
   await(scripts_get_custom_runs, id = job$id, run_id = run$id)
   if (JSONValue) {
+
      output <- fetch_output(civis_script(job$id, run$id))
      json_output <- output[sapply(output, function(o) o$objectType=="JSONValue")]
-     if (length(json_output) > 1) {
-        cat("Error in returning JSON outputs of template run -- too many JSON outputs")
+
+     if (length(json_output) == 0) {
+        warning("Error in returning JSON outputs of template run -- no JSON output")
 	return()
      }
-     if (length(json_output) == 0) {
-        cat("Error in returning JSON outputs of template run -- no JSON output")
-	return()
+     if (length(json_output) > 1) {
+        warning("Error in returning JSON outputs of template run -- too many JSON outputs")
      }
      return(json_output[[1]]$value)
+
   }
   else {
      file_ids = fetch_output_file_ids(civis_script(job$id, run$id))

--- a/R/scripts.R
+++ b/R/scripts.R
@@ -88,8 +88,11 @@ run_civis <- function(expr, ...) {
 #' Run a template script
 #' @param id id of the template script.
 #' @param arguments list of arguments to the script.
+#' @param JSONValue (default FALSE) If true, returns the 
+#'                  JSON values instead of the file_ids
 #' @param ... additional arguments to \code{scripts_post_custom}
-#' @return File ids of any run outputs are returned.
+#' @return If JSONValue is TRUE, File ids of any run outputs are returned.
+#'         If JSONValue is FALSE, JSON values of any run outputs are returned.
 #' @export
 #' @family script_utils
 #' @examples
@@ -100,19 +103,18 @@ run_civis <- function(expr, ...) {
 #' # Run the template
 #' run_template(id, arguments = list(arg1 = 1, arg2 = 2), ...)
 #' }
-run_template <- function(id, arguments, JSONvalue=FALSE, ...) {
+run_template <- function(id, arguments, JSONValue=FALSE, ...) {
   job <- scripts_post_custom(id, arguments = arguments, ...)
   run <- scripts_post_custom_runs(job$id)
   await(scripts_get_custom_runs, id = job$id, run_id = run$id)
-  file_ids = fetch_output_file_ids(civis_script(job$id, run$id))
-  if (JSONvalue) {
-     file_contents = c()
-     for (f in file_ids) {
-         file_content = json_values_get(f)
-       	 file_contents = c(file_contents, file_content)
-     }
+  if (JSONValue) {
+     output <- fetch_output(civis_script(job$id, run$id))
+     names <- lapply(output, function(o) o$name)
+     file_values <- stats::setNames(lapply(output, function(o) o$value), names)
+     return(file_values)
   }
   else {
+     file_ids = fetch_output_file_ids(civis_script(job$id, run$id))
      return(file_ids)
   }
 }

--- a/R/scripts.R
+++ b/R/scripts.R
@@ -100,11 +100,21 @@ run_civis <- function(expr, ...) {
 #' # Run the template
 #' run_template(id, arguments = list(arg1 = 1, arg2 = 2), ...)
 #' }
-run_template <- function(id, arguments, ...) {
+run_template <- function(id, arguments, JSONvalue=FALSE, ...) {
   job <- scripts_post_custom(id, arguments = arguments, ...)
   run <- scripts_post_custom_runs(job$id)
   await(scripts_get_custom_runs, id = job$id, run_id = run$id)
-  fetch_output_file_ids(civis_script(job$id, run$id))
+  file_ids = fetch_output_file_ids(civis_script(job$id, run$id))
+  if (JSONvalue) {
+     file_contents = c()
+     for (f in file_ids) {
+         file_content = json_values_get(f)
+       	 file_contents = c(file_contents, file_content)
+     }
+  }
+  else {
+     return(file_ids)
+  }
 }
 
 #' Add a file as a run output if called from a container job

--- a/R/scripts.R
+++ b/R/scripts.R
@@ -88,7 +88,7 @@ run_civis <- function(expr, ...) {
 #' Run a template script
 #' @param id id of the template script.
 #' @param arguments list of arguments to the script.
-#' @param JSONValue (default FALSE) If true, returns the 
+#' @param JSONValue bool (default FALSE) If true, returns the 
 #'                  JSON values instead of the file_ids
 #' @param ... additional arguments to \code{scripts_post_custom}
 #' @return If JSONValue is TRUE, File ids of any run outputs are returned.
@@ -102,6 +102,9 @@ run_civis <- function(expr, ...) {
 #'
 #' # Run the template
 #' run_template(id, arguments = list(arg1 = 1, arg2 = 2), ...)
+#'
+#' # Run the template and return JSON value outputs
+#' run_template(id, arguments = list(arg1 = 1, arg2 = 2), JSONValue=TRUE...)
 #' }
 run_template <- function(id, arguments, JSONValue=FALSE, ...) {
   job <- scripts_post_custom(id, arguments = arguments, ...)

--- a/man/run_template.Rd
+++ b/man/run_template.Rd
@@ -19,9 +19,10 @@ JSON values instead of the file_ids}
 \value{
 If JSONValue is FALSE, File ids of any run outputs are returned.
         If JSONValue is TRUE, JSON values of first JSON run output is returned.
-          If there are no JSON outputs, nothing is returned
-          If there are more than 1 JSON outputs, error message is printed 
-            and nothing is returned.
+          If there are no JSON outputs, warning message is printed
+            and nothing is returned
+          If there are more than 1 JSON outputs, warning message is printed 
+            and the first JSON output is returned.
 }
 \description{
 Run a template script

--- a/man/run_template.Rd
+++ b/man/run_template.Rd
@@ -17,8 +17,11 @@ JSON values instead of the file_ids}
 \item{...}{additional arguments to \code{scripts_post_custom}}
 }
 \value{
-If JSONValue is TRUE, File ids of any run outputs are returned.
-        If JSONValue is FALSE, JSON values of any run outputs are returned.
+If JSONValue is FALSE, File ids of any run outputs are returned.
+        If JSONValue is TRUE, JSON values of first JSON run output is returned.
+          If there are no JSON outputs, nothing is returned
+          If there are more than 1 JSON outputs, error message is printed 
+            and nothing is returned.
 }
 \description{
 Run a template script

--- a/man/run_template.Rd
+++ b/man/run_template.Rd
@@ -4,17 +4,21 @@
 \alias{run_template}
 \title{Run a template script}
 \usage{
-run_template(id, arguments, ...)
+run_template(id, arguments, JSONValue = FALSE, ...)
 }
 \arguments{
 \item{id}{id of the template script.}
 
 \item{arguments}{list of arguments to the script.}
 
+\item{JSONValue}{bool (default FALSE) If true, returns the 
+JSON values instead of the file_ids}
+
 \item{...}{additional arguments to \code{scripts_post_custom}}
 }
 \value{
-File ids of any run outputs are returned.
+If JSONValue is TRUE, File ids of any run outputs are returned.
+        If JSONValue is FALSE, JSON values of any run outputs are returned.
 }
 \description{
 Run a template script
@@ -26,6 +30,9 @@ search_list('template name', type = 'template_script')
 
 # Run the template
 run_template(id, arguments = list(arg1 = 1, arg2 = 2), ...)
+
+# Run the template and return JSON value outputs
+run_template(id, arguments = list(arg1 = 1, arg2 = 2), JSONValue=TRUE...)
 }
 }
 \seealso{

--- a/man/run_template.Rd
+++ b/man/run_template.Rd
@@ -36,7 +36,7 @@ search_list('template name', type = 'template_script')
 run_template(id, arguments = list(arg1 = 1, arg2 = 2), ...)
 
 # Run the template and return JSON value outputs
-run_template(id, arguments = list(arg1 = 1, arg2 = 2), JSONValue=TRUE...)
+run_template(id, arguments = list(arg1 = 1, arg2 = 2), JSONValue=TRUE, ...)
 }
 }
 \seealso{

--- a/tests/testthat/test_scripts.R
+++ b/tests/testthat/test_scripts.R
@@ -66,6 +66,58 @@ test_that("run_template", {
                list(1, arguments = list(arg = 1), credential_id = 1))
 })
 
+test_that("run_template_with_json", {
+  mock_output <- list(list(name = 'a', objectId = 1, objectType = 'JSONValue', value = "{'a':1}"))
+  mock_post <- mockery::mock(list(id = 1))
+  vals <- with_mock(
+    `civis::scripts_post_custom` =  mock_post,
+    `civis::scripts_post_custom_runs` = function(...) list(id = 1),
+    `civis::scripts_get_custom_runs` = function(...) list(state = 'succeeded'),
+    `civis::jobs_get` = function(...) list(type = 'JobTypes::ContainerDocker', fromTemplateId = 1),
+    `civis::scripts_list_custom_runs_outputs` = function(...) mock_output,
+    run_template(1, arguments = list(arg = 1), credential_id = 1, JSONValue=TRUE)
+  )
+  expect_equal(vals, "{'a':1}")
+  mockery::expect_called(mock_post, 1)
+  expect_equal(mockery::mock_args(mock_post)[[1]],
+               list(1, arguments = list(arg = 1), credential_id = 1))
+})
+
+test_that("run_template_with_no_json_output", {
+  mock_output <- list(list(name = 'a', objectId = 1, objectType = 'JSONValue', value = "{'a':1}"),
+  	      	      list(name = 'b', objectId = 2, objectType = 'JSONValue', value = "{'b':2}"))
+  mock_post <- mockery::mock(list(id = 1))
+  vals <- with_mock(
+    `civis::scripts_post_custom` =  mock_post,
+    `civis::scripts_post_custom_runs` = function(...) list(id = 1),
+    `civis::scripts_get_custom_runs` = function(...) list(state = 'succeeded'),
+    `civis::jobs_get` = function(...) list(type = 'JobTypes::ContainerDocker', fromTemplateId = 1),
+    `civis::scripts_list_custom_runs_outputs` = function(...) mock_output,
+    run_template(1, arguments = list(arg = 1), credential_id = 1, JSONValue=TRUE)
+  )
+  expect_equal(vals, "{'a':1}")
+  mockery::expect_called(mock_post, 1)
+  expect_equal(mockery::mock_args(mock_post)[[1]],
+               list(1, arguments = list(arg = 1), credential_id = 1))
+})
+
+test_that("run_template_with_multiple_json_output", {
+  mock_output <- list(list(name = 'a', objectId = 1, objectType = 'int'))
+  mock_post <- mockery::mock(list(id = 1))
+  vals <- with_mock(
+    `civis::scripts_post_custom` =  mock_post,
+    `civis::scripts_post_custom_runs` = function(...) list(id = 1),
+    `civis::scripts_get_custom_runs` = function(...) list(state = 'succeeded'),
+    `civis::jobs_get` = function(...) list(type = 'JobTypes::ContainerDocker', fromTemplateId = 1),
+    `civis::scripts_list_custom_runs_outputs` = function(...) mock_output,
+    run_template(1, arguments = list(arg = 1), credential_id = 1, JSONValue=TRUE)
+  )
+  expect_equal(vals, NULL)
+  mockery::expect_called(mock_post, 1)
+  expect_equal(mockery::mock_args(mock_post)[[1]],
+               list(1, arguments = list(arg = 1), credential_id = 1))
+})
+
 test_that("run_civis", {
   # CivisFuture is tested extensively elsewhere.
   with_mock(


### PR DESCRIPTION
Modified run_template() so that if specified, the JSON values are returned instead of the associated file ids