### PR TITLE
Remove models_ endpoints from docs

### DIFF
--- a/_pkgdown.yaml
+++ b/_pkgdown.yaml
@@ -41,6 +41,14 @@ reference:
       contents:
       - publish_rmd
       - publish_html
+    - title: Scripts
+      desc: Using Civis Scripts
+      contents:
+      - run_template
+      - civis_script
+      - write_job_output
+      - run_civis
+      - fetch_output_file_ids
     - title: Tables
       desc: Utilities for working with Redshift Tables
       contents:
@@ -70,4 +78,5 @@ reference:
     - title: API
       desc: Direct API calls to the Civis Platform
       contents:
-      - matches("^\\w*_(delete|get|list|patch|post|put)")
+      - matches("\\w*(get|post|patch|put|delete)")
+      - -matches("^models_")

--- a/man/publish_rmd.Rd
+++ b/man/publish_rmd.Rd
@@ -22,7 +22,7 @@ report will be created.}
 
 \item{...}{additional parameters to send to \code{rmarkdown::render}. Note:
 A temporary file will be used for \code{output_file} if \code{output_file}
-is not explicity set and \code{input} will be overwritten with
+is not explicitly set and \code{input} will be overwritten with
 \code{rmd_file}.}
 }
 \description{
@@ -40,7 +40,7 @@ with \code{title: "my title!"}, these parameters can be set like
 }
 Since \code{report_id} is set, this code will overwrite the existing
 report with that number, which may be useful when updating a report on
-a schedule.  Any argument passed in explicity to \code{publish_rmd}
+a schedule.  Any argument passed in explicitly to \code{publish_rmd}
 will be used in place of the corresponding argument set in YAML metadata.
 }
 \note{


### PR DESCRIPTION
This removes `models_` endpoints from docs and adds a section for Scripts. I think the docs have to be generated and deployed separately.