### PR TITLE
ENH: global option for await polling interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Changed
 - `run_template` takes an additional value of JSONValue. If TRUE,
-  frunction returns the JSON output instead of the fileid.
+  function returns the JSON output instead of the fileid.
+
+### Added
+- Provided package option `civis.default_polling_interval` to globally 
+set the interval for polling via `await` (#204).
 
 ## [2.0.0] - 2019-06-19
 

--- a/R/await.R
+++ b/R/await.R
@@ -75,12 +75,15 @@
 #' \item{11-19: 5-10s}
 #' \item{20-29: 10s - 1m}
 #' }
+#' The polling interval can be set to a fixed value globally with
+#' \code{options("civis.default_polling_interval" = INTERVAL_IN_SECONDS)}.
 #' @seealso \code{\link{get_status}, \link{get_error}, \link{fetch_logs}}
 await <- function(f, ...,
                   .status_key = "state",
                   .success_states = c("succeeded", "success"),
                   .error_states = c("failed", "cancelled"),
-                  .timeout = NULL, .interval = NULL,
+                  .timeout = NULL,
+                  .interval = getOption("civis.default_polling_interval"),
                   .verbose = FALSE) {
   start <- Sys.time()
   i <- 1

--- a/man/await.Rd
+++ b/man/await.Rd
@@ -7,7 +7,9 @@
 \usage{
 await(f, ..., .status_key = "state", .success_states = c("succeeded",
   "success"), .error_states = c("failed", "cancelled"),
-  .timeout = NULL, .interval = NULL, .verbose = FALSE)
+  .timeout = NULL,
+  .interval = getOption("civis.default_polling_interval"),
+  .verbose = FALSE)
 
 await_all(f, .x, .y = NULL, ..., .status_key = "state",
   .success_states = c("succeeded", "success"),
@@ -82,6 +84,8 @@ Approximate intervals for a given number of retries are as follows:
 \item{11-19: 5-10s}
 \item{20-29: 10s - 1m}
 }
+The polling interval can be set to a fixed value globally with
+\code{options("civis.default_polling_interval" = 1)}
 }
 \section{Functions}{
 \itemize{

--- a/man/publish_rmd.Rd
+++ b/man/publish_rmd.Rd
@@ -22,7 +22,7 @@ report will be created.}
 
 \item{...}{additional parameters to send to \code{rmarkdown::render}. Note:
 A temporary file will be used for \code{output_file} if \code{output_file}
-is not explicity set and \code{input} will be overwritten with
+is not explicitly set and \code{input} will be overwritten with
 \code{rmd_file}.}
 }
 \description{
@@ -40,7 +40,7 @@ with \code{title: "my title!"}, these parameters can be set like
 }
 Since \code{report_id} is set, this code will overwrite the existing
 report with that number, which may be useful when updating a report on
-a schedule.  Any argument passed in explicity to \code{publish_rmd}
+a schedule.  Any argument passed in explicitly to \code{publish_rmd}
 will be used in place of the corresponding argument set in YAML metadata.
 }
 \note{

--- a/tests/testthat/test_await.R
+++ b/tests/testthat/test_await.R
@@ -77,6 +77,10 @@ test_that("await throws a civis_timeout_error on timeout", {
   expect_equal(e, e2)
 })
 
+test_that("default interval is null", {
+  expect_null(getOption("civis.default_polling_interval"))
+})
+
 test_that("get_error returns error data for civis_error", {
   f <- function(x) {
     if (x == 0) {
@@ -258,3 +262,4 @@ test_that("await_all catches arbitrary status and keys - multivariate", {
   expect_equal(sapply(x, get_status), rep("going home", 2))
   expect_equal(sapply(x, function(x) x$value), 1:2)
 })
+


### PR DESCRIPTION
This provides a global option to set the default polling interval. This will allow a user to poll less often during computationally intensive jobs that are kicked off in parallel.