### PR TITLE
FIX: civis_future version for civis 2.0

### DIFF
--- a/inst/scripts/r_remote_eval.R
+++ b/inst/scripts/r_remote_eval.R
@@ -29,14 +29,5 @@ detach(fut$envir)
 
 cat("Complete.", fill = TRUE)
 
-
-# store results on s3
-output_file_id <- write_civis_file(res)
-cat("Output file id: ", output_file_id, fill = TRUE)
-
-# attach to the job output
-script_id <- Sys.getenv("CIVIS_JOB_ID")
-run_id <- Sys.getenv("CIVIS_RUN_ID")
-resp <- scripts_post_containers_runs_outputs(script_id, run_id,
-                                              object_type = "File",
-                                              object_id = output_file_id)
+saveRDS(res, file = 'r-object.rds')
+write_job_output("r-object.rds")

--- a/tests/testthat/test_civis_future.R
+++ b/tests/testthat/test_civis_future.R
@@ -15,6 +15,7 @@ mock_r_eval <- function(fut) {
     `civis::scripts_post_containers_runs_outputs` = function(...) NULL,
     `civis::write_civis_file` = function(...) NULL,
     eval(r_remote_eval),
+    unlink('r-object.rds'),
     return(res)
   )
 }

--- a/tools/integration_tests/smoke_test.R
+++ b/tools/integration_tests/smoke_test.R
@@ -178,6 +178,7 @@ test_that("additional packages get installed", {
 })
 
 test_that("environment is attached", {
+  plan(civis_platform)
   f <- function(x) g(x)
   g <- function(x) x
   fut <- future({f(1)})


### PR DESCRIPTION
This fixes the integration test failure for CivisFuture. Upgrading the docker version upgraded the `civis` version to `2.0` in the container. The new `write_civis_file` default uploaded the data frame in the test as a csv, breaking `value.CivisFuture`.

This patch standardizes the output of CivisFuture to RDS, retaining the original name.

The CivisFuture integration tests now also pass. 