### PR TITLE
More retries on rate-limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 ### Changed
 - `run_template` takes an additional value of JSONValue. If TRUE,
   function returns the JSON output instead of the fileid.
+- All API calls now retry a max of 10 times for maximum of 1 hr when rate limited. (#214).
   
 ### Fixed
 - Bug in handling of environments in CivisFuture (#205).
+- Bug in error handling on API responses with no `errorDescription` (#214)
 
 ### Added
 - Provided package option `civis.default_polling_interval` to globally 

--- a/R/client_base.R
+++ b/R/client_base.R
@@ -129,7 +129,9 @@ stop_for_status <- function(x, task = NULL) {
     return(invisible(x))
 
   call <- sys.call(-1)
-  error_msg <- httr::content(x)$errorDescription
+  # e.g. 429, 503 do not have errorDescription fields
+  error_msg <- tryCatch(httr::content(x)$errorDescription,
+                        error = function(e) "")
   condition <- httr::http_condition(x, "error", task = task, call = call)
   condition$message <- paste0(c(condition$message, error_msg), collapse = " ")
   stop(condition)

--- a/R/client_base.R
+++ b/R/client_base.R
@@ -20,8 +20,6 @@ print.civis_api <- function(x, ...) {
   invisible(resp)
 }
 
-
-
 call_api <- function(verb, path, path_params, query_params, body_params) {
     url <- build_url(path, path_params)
     auth <- httr::authenticate(api_key(), "")
@@ -43,11 +41,15 @@ call_api <- function(verb, path, path_params, query_params, body_params) {
       retry_on <- c(413, 429, 502, 503, 504)
       terminate_on <- setdiff(200:527, retry_on)
       request <- httr::RETRY
-      request_args <- c(request_args, list(terminate_on = terminate_on))
+      request_args <- c(request_args, list(terminate_on = terminate_on,
+                                           pause_cap = 600,
+                                           times = 10))
     } else {
       # Retry on all other verbs only if 429.
       terminate_on <- setdiff(200:527, 429)
-      request_args <- c(request_args, list(terminate_on = terminate_on))
+      request_args <- c(request_args, list(terminate_on = terminate_on,
+                                           pause_cap = 600,
+                                           times = 10))
       request <- httr::RETRY
     }
     response <- do.call(request, request_args)

--- a/tests/testthat/test_client_base.R
+++ b/tests/testthat/test_client_base.R
@@ -117,10 +117,10 @@ test_that("retry on GET/POST on 429", {
     `httr:::backoff_full_jitter` = function(...) Sys.sleep(0),
     expect_error(call_api("GET", path, path_params, query_params, body_params),
                  paste0(httr_429$status_code)),
-    expect_called(mock_rp, 3),
+    expect_called(mock_rp, 10),
     expect_error(call_api("POST", path, path_params, query_params, body_params),
                paste0(httr_429$status_code)),
-    expect_called(mock_rp, 6))
+    expect_called(mock_rp, 20))
 })
 
 test_that("failing to parse JSON content returns CivisClientError", {


### PR DESCRIPTION
This increases default retrying for `call_api`. Changes:

- When rate limiting, all verbs can be safely retried. Fixes #201 .
- Increase the default retries to 10, with maximum wait time for 1 hour. Fixes #210 .
- Fix assumption in error handling that an `errorDescription` field is provided in the response (it isn't for at least 429). Fixes #213 .

The smoke tests successfully ran locally.

Do you mind one last civis-r code review @keithing ? 