### PR TITLE
FIX: The `database` parameter in `read_civis` now works with glue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- The `database` parameter in `read_civis` now accepts character
+objects of class `glue`.
+
 ## [2.1.0] - 2019-09-06
 
 ### Changed

--- a/R/utils.R
+++ b/R/utils.R
@@ -8,7 +8,7 @@
 get_database_id <- function(database_name) {
   dbs <- databases_list()
   for (db in dbs) {
-    if (identical(db$name, database_name)) {
+    if (db$name == database_name) {
       return(db$id)
     }
   }

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -12,10 +12,13 @@ db_list_response <- list(
 )
 
 test_that("get_database_id returns a matching id", {
+  # simulates a character of class glue often used for
+  # string interpolation
+  glue_str <- structure("db1", class = c("glue", "character"))
   with_mock(
     `civis::databases_list` = function(...) db_list_response,
-    expect_equal(get_database_id("db2"), 2),
-    expect_equal(get_database_id("db1"), 1)
+    expect_equal(get_database_id(glue_str), 1),
+    expect_equal(get_database_id("db2"), 2)
   )
 })
 


### PR DESCRIPTION
This bug popped up in office hours, and just wanted to fix.

Context: checking whether a provided database is equal to another with `identical` requires that the classes of the two objects are the same. However, if a string has been interpolated with e.g. `str_glue`, `identical` fails because the classes aren't the same:

```
 class(str_glue('a'))
[1] "glue"      "character"

identical(str_glue('a'), 'a')
[1] FALSE
```
Checking that the values are the same (not the objects) fixes the bug.

Thanks @lmalkovich for the report!