### PR TITLE
[PARO-741] DOC update language for CivisML version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ objects of class `glue`.
 - CivisML uses platform aliases instead of hard-coded template IDs. (#221)
 
 ### Added
-- Provided parameter for user to optionally specify the CivisML version (#224)
+- Provided parameter for user to optionally specify the CivisML version (#224, #225)
 
 ## [2.1.0] - 2019-09-06
 

--- a/vignettes/civis_ml.Rmd
+++ b/vignettes/civis_ml.Rmd
@@ -342,8 +342,9 @@ Modeling data must be complete. Any missing values will be imputed with the mean
 
 ### CivisML Versions
 
-By default, CivisML uses its latest version in production. Under special
-circumstances, if you would like a specific version (e.g., an older version),
+By default, CivisML uses its latest version in production.
+If you would like a specific version
+(e.g., for a production pipeline where pinning the CivisML version is desirable),
 both `civis_ml` and the `civis_ml_*` functions have the optional parameter
 ``civisml_version`` that accepts a string, e.g., ``'v2.3'``
 for CivisML v2.3. Please see [here](https://civis.zendesk.com/hc/en-us/articles/360000260011-CivisML) for the list of CivisML versions.


### PR DESCRIPTION
The documentation for the CivisML version implies that the major use of the civisml_version parameter (added in #224) is to use an older version of CivisML, which seems slightly misleading (for clarity, this original language came from my changes at https://github.com/civisanalytics/civis-python/pull/341, not Sahil's -- my bad). I'm updating the docs to clarify that it's about pinning the version for production work as a more probable use case.

The parallel PR for civis-python is https://github.com/civisanalytics/civis-python/pull/358