### PR TITLE
DOC add website link to description file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ objects of class `glue`.
 - CivisML uses platform aliases instead of hard-coded template IDs. (#221)
 
 ### Added
+- Added link to full website documentation in DESCRIPTION (#226)
 - Provided parameter for user to optionally specify the CivisML version (#224, #225)
 
 ## [2.1.0] - 2019-09-06

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,7 @@ Authors@R: c(
   person("Sahil", "Shah", email = "sshah2@civisanalytics.com", role = "ctb"))
 Description: A convenient interface for making
   requests directly to the 'Civis Platform API' <https://www.civisanalytics.com/platform/>.
+  Full documentation available 'here' <https://civisanalytics.github.io/civis-r/>.
 Depends:
     R (>= 3.2.0)
 License: BSD_3_clause + file LICENSE


### PR DESCRIPTION
Adds a website link to the DESCRIPTION file. The change to the page title already happened in a PR about a month ago (#222), so no changes to make there. Closes #184.