### PR TITLE
Maintainer must be a person

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: civis
 Title: R Client for the 'Civis Platform API'
 Version: 2.1.1
 Authors@R: c(
-  person("Patrick", "Miller", email = "pmiller@civisanalytics.com", role = c("cre", "aut"),
+  person("Patrick", "Miller", email = "pmiller@civisanalytics.com", role = c("cre", "aut")),
   person("Keith", "Ingersoll", email = "kingersoll@civisanalytics.com", role = "aut"),
   person("Bill", "Lattner", email = "wlattner@civisanalytics.com", role = "ctb"),
   person("Anh", "Le", email = "ale@civisanalytics.com", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,7 @@ Package: civis
 Title: R Client for the 'Civis Platform API'
 Version: 2.1.1
 Authors@R: c(
-  person("Ann", "Droid", email = "civis-api-clients-robot@civisanalytics.com", role = "cre"),
-  person("Patrick", "Miller", email = "pmiller@civisanalytics.com", role = "aut"),
+  person("Patrick", "Miller", email = "pmiller@civisanalytics.com", role = c("cre", "aut"),
   person("Keith", "Ingersoll", email = "kingersoll@civisanalytics.com", role = "aut"),
   person("Bill", "Lattner", email = "wlattner@civisanalytics.com", role = "ctb"),
   person("Anh", "Le", email = "ale@civisanalytics.com", role = "ctb"),


### PR DESCRIPTION
Unfortunately this is covered in writing R extensions. I assume that the package will get rejected with a bot/mailing list listed as a maintainer.

> The mandatory ‘Maintainer’ field should give a single name followed by a valid (RFC 2822) email address in angle brackets. It should not end in a period or comma. This field is what is reported by the maintainer function and used by bug.report. For a CRAN package it should be a person, not a mailing list and not a corporate entity: do ensure that it is valid and will remain valid for the lifetime of the package.

> Note that the display name (the part before the address in angle brackets) should be enclosed in double quotes if it contains non-alphanumeric characters such as comma or period. (The current standard, RFC 5322, allows periods but RFC 2822 did not.)

> Both ‘Author’ and ‘Maintainer’ fields can be omitted if a suitable ‘Authors@R’ field is given. This field can be used to provide a refined and machine-readable description of the package “authors” (in particular specifying their precise roles), via suitable R code. It should create an object of class "person", by either a call to person or a series of calls (one per “author”) concatenated by c(): see the example DESCRIPTION file above. The roles can include ‘"aut"’ (author) for full authors, ‘"cre"’ (creator) for the package maintainer, and ‘"ctb"’ (contributor) for other contributors, ‘"cph"’ (copyright holder), among others. See ?person for more information. Note that no role is assumed by default. Auto-generated package citation information takes advantage of this specification. The ‘Author’ and ‘Maintainer’ fields are auto-generated from it if needed when building5 or installing.