### PR TITLE
FIX: stringsAsFactors

### DIFF
--- a/R/civis_ml_utils.R
+++ b/R/civis_ml_utils.R
@@ -285,7 +285,7 @@ get_feature_importance <- function(model){
   importance <- params$feature_importances[variable_order]
 
   feature_importance_df <- data.frame('variable_name' = variable_name,
-                                      'importance' = importance)
+                                      'importance' = importance, stringsAsFactors = TRUE)
   feature_importance_df
 }
 

--- a/tests/testthat/test_io.R
+++ b/tests/testthat/test_io.R
@@ -292,7 +292,7 @@ test_that("write_civis_file.data.frame uploads a csv", {
     write_civis_file(iris),
     # call the temporary function given to with_tempfile
     mock_args(m)[[1]][[1]]('tmp.csv'),
-    expect_equal(read.csv('tmp.csv'), iris),
+    expect_equal(read.csv('tmp.csv', stringsAsFactors = TRUE), iris),
     unlink('tmp.csv')
   )
 })

--- a/tools/integration_tests/smoke_test.R
+++ b/tools/integration_tests/smoke_test.R
@@ -35,7 +35,7 @@ test_that("write_civis writes to redshift", {
   # Tests both write_civis.character and write_civis.default
   iris$id <- 1:nrow(iris)
   write_civis(iris, tablename, database = database, verbose = TRUE)
-  x <- read_civis(tablename)
+  x <- read_civis(tablename, stringsAsFactors = TRUE)
   colnames(x) <- colnames(iris)
   expect_equivalent(x[order(x$id), ], iris)
   query_civis(paste0("DROP TABLE IF EXISTS ", tablename), database = database)
@@ -46,7 +46,7 @@ test_that("write_civis writes to redshift", {
   write.csv(iris, file = fname, row.names = TRUE)
   fid <- write_civis_file(fname, "iris.csv")
   write_civis(fid, tablename, "redshift-general", if_exists = "drop", verbose = TRUE)
-  x <- read_civis(tablename)
+  x <- read_civis(tablename, stringsAsFactors = TRUE)
   id <- x[,1]
   x$column_0 <- NULL
   colnames(x) <- colnames(iris)
@@ -91,7 +91,7 @@ test_that("files can be uploaded", {
   # tests both write_civis_file.default and write_civis_file.character
   data(iris)
   fid <- write_civis_file(iris)
-  x <- read_civis(fid)
+  x <- read_civis(fid, using = read.csv, stringsAsFactors = TRUE)
   expect_equal(x, iris)
 
   info <- files_get(id = fid)


### PR DESCRIPTION
After the `stringsAsFactors` default change in R-devel, there are two errors in the package that caused `R CMD CHECK` failures:
https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/civis-00check.html

I decided to preserve `stringsAsFactors=TRUE`  when returning feature importances, since the package  originally returned feature importances as a data frame with factors.

The breaking test for `write_civis_file` highlights that this breaking change in R may affect users downstream. For example, calls to `read_civis` with default arguments will now return data frames from `read.csv` where `stringsAsFactors=FALSE`. 

We could insulate our users from this change by specifying `stringsAsFactors=TRUE` in `read_civis` calls as the  default. However, I don't feel that it is our responsibility to prevent breaking changes caused by base R in this package, or to provide different defaults for base R functions (in this case `read.csv)`.