### PR TITLE
fix smoke test by relaxing expected file count from multifile unload

### DIFF
--- a/tools/integration_tests/smoke_test.R
+++ b/tools/integration_tests/smoke_test.R
@@ -74,7 +74,7 @@ test_that("queries are executed", {
 
 test_that("civis_to_multifile produces csv links", {
   x <- civis_to_multifile_csv("SELECT * FROM datascience.iris", "redshift-general")
-  expect_equal(length(x$entries), 31)
+  expect_gt(length(x$entries), 1)
   expect_equal(x$query, "SELECT * FROM datascience.iris")
 })
 


### PR DESCRIPTION
This fixes/relaxes a test that had hardcoded an assumption about an old redshift cluster config.