### PR TITLE
FIX cass/ncoa doc param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## Unreleased
 
+
 ### Changed
 - Failed HTTP requests are now retried before raising errors (#235)
 - Default docker image for Civis Futures is now `latest` rather than `3` (#238)
+
+### Fixed
+- Fixed auto-documentation bug for some endpoints with parameters that are nested objects. `enhancements_[verb]_cass_ncoa`, `exports_[verb]_files,`
+and `imports_[verb]_files` have updated documentation as a result. (#240)
 
 ## [2.1.2] - 2020-02-24
 

--- a/R/generate_client.R
+++ b/R/generate_client.R
@@ -223,8 +223,12 @@ write_nested_docs <- function(x) {
     doc_str <- paste0(doc_str,
         "A list containing the following elements: \n#' \\itemize{\n")
     for (i in seq_along(ps)) {
-      doc_str <- paste0(doc_str,
-        sprintf(fmt, names(ps)[i], ps[[i]]$type, get_descr_str(ps[[i]])), "\n")
+      if(is_obj(ps[[i]])) {
+        doc_str <- paste0(doc_str, write_properties(ps[i], fmt = "#' \\item %s %s %s. %s"))
+      } else {
+        doc_str <- paste0(doc_str,
+          sprintf(fmt, names(ps)[i], ps[[i]]$type, get_descr_str(ps[[i]])), "\n")
+      }
     }
     doc_str <- paste0(doc_str, "#' }")
   }


### PR DESCRIPTION
Incidentally, this also fixes doc bugs for a few other endpoints (noted in the changelog).

I regenerated the docs locally for testing, here are the results:
![Screen Shot 2020-06-18 at 9 28 49 AM](https://user-images.githubusercontent.com/427445/85034128-5da35100-b147-11ea-8f08-68fa1c990a74.png)


![Screen Shot 2020-06-18 at 9 30 21 AM](https://user-images.githubusercontent.com/427445/85034095-5419e900-b147-11ea-8c04-57bafe1bafe5.png)

`databaseTable` and `storagePath` lists were not documented previously.

I will update the client/docs in the 3.0.0 release PR.

Fixes #220.