### PR TITLE
Patch fetch_all pagination helper

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,8 @@ Authors@R: c(
   person("Elizabeth", "Sander", email = "lsander@civisanalytics.com", role = "ctb"),
   person("Madison", "Hobbs", email = "mhobbs@g.hmc.edu", role = "ctb"),
   person("Anna", "Bladey", email = "abladey@civisanalytics.com", role = "ctb"),
-  person("Sahil", "Shah", email = "sshah2@civisanalytics.com", role = "ctb"))
+  person("Sahil", "Shah", email = "sshah2@civisanalytics.com", role = "ctb")),
+  person("Bryan", "Baird", email = "bbaird@civisanalytics.com", role = "ctb"))
 Description: A convenient interface for making
   requests directly to the 'Civis Platform API' <https://www.civisanalytics.com/platform/>.
   Full documentation available 'here' <https://civisanalytics.github.io/civis-r/>.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Authors@R: c(
   person("Elizabeth", "Sander", email = "lsander@civisanalytics.com", role = "ctb"),
   person("Madison", "Hobbs", email = "mhobbs@g.hmc.edu", role = "ctb"),
   person("Anna", "Bladey", email = "abladey@civisanalytics.com", role = "ctb"),
-  person("Sahil", "Shah", email = "sshah2@civisanalytics.com", role = "ctb")),
+  person("Sahil", "Shah", email = "sshah2@civisanalytics.com", role = "ctb"),
   person("Bryan", "Baird", email = "bbaird@civisanalytics.com", role = "ctb"))
 Description: A convenient interface for making
   requests directly to the 'Civis Platform API' <https://www.civisanalytics.com/platform/>.

--- a/R/pagination_helpers.R
+++ b/R/pagination_helpers.R
@@ -41,7 +41,7 @@ next_page <- function(response) {
 #' column_names <- columns %>% purrr::map_chr("name")
 #' }
 fetch_all <- function(fn, ...) {
-  fetch_until(fn, function(x) x == FALSE, ...)
+  fetch_until(fn, function(x) is.null(x), ...)
 }
 
 #' Retrieve some results from a paginated endpoint


### PR DESCRIPTION
The `fetch_all` function is intended to call `fetch_until` until a result of `FALSE` is returned. However, when the API returns no result, that output manifests as a NULL, not a boolean `FALSE` value. This change prevents a coercion error of trying to boolean compare a NULL value in R.