### PR TITLE
Replace deprecated ggplot2 functions in CivisML plots

### DIFF
--- a/R/civis_ml_plot.R
+++ b/R/civis_ml_plot.R
@@ -27,7 +27,7 @@ hist.civis_ml <- function(x, name = NULL, ...) {
   if (!is.null(name)) df <- subset(df, names == name)
 
   ggplot2::ggplot(df) +
-    ggplot2::geom_bar(ggplot2::aes_string(x = "mp", y = "freq"), stat = "identity") +
+    ggplot2::geom_bar(ggplot2::aes(x = mp, y = freq), stat = "identity") +
     ggplot2::xlab("OUT OF SAMPLE SCORES") +
     ggplot2::ylab("DENSITY") +
     ggplot2::scale_y_continuous(labels = percent) +
@@ -58,7 +58,7 @@ plot.civis_ml_regressor <- function(x, ...) {
 
   df$x <- y_vals[df$row_id]
   df$y <- yhat_vals[df$col_id]
-  ggplot2::ggplot(df, ggplot2::aes_string(x = "x", y = "y", fill = "values")) +
+  ggplot2::ggplot(df, ggplot2::aes(x = x, y = y, fill = values)) +
     ggplot2::geom_tile() +
     ggplot2::scale_fill_gradient("Bin Size", low = "white", high = civisblue) +
     ggplot2::geom_abline(intercept = 0, slope = 1, color = civisyellow) +
@@ -93,7 +93,7 @@ plot.civis_ml_classifier <- function(x, name =  NULL, ...) {
 
   if (!is.null(name)) decile_df <- subset(decile_df, names == name)
 
-  ggplot2::ggplot(decile_df, ggplot2::aes_string(x = "decile", y = "values")) +
+  ggplot2::ggplot(decile_df, ggplot2::aes(x = decile, y = values)) +
     ggplot2::geom_bar(stat = 'identity', fill = "gray") +
     ggplot2::geom_hline(yintercept = incidence, color = civisyellow, size = 2, linetype = 8) +
     ggplot2::annotate("text", x = 4, y = incidence + 0.03,

--- a/R/civis_ml_plot.R
+++ b/R/civis_ml_plot.R
@@ -95,7 +95,7 @@ plot.civis_ml_classifier <- function(x, name =  NULL, ...) {
 
   ggplot2::ggplot(decile_df, ggplot2::aes(x = decile, y = values)) +
     ggplot2::geom_bar(stat = 'identity', fill = "gray") +
-    ggplot2::geom_hline(yintercept = incidence, color = civisyellow, size = 2, linetype = 8) +
+    ggplot2::geom_hline(yintercept = incidence, color = civisyellow, linewidth = 2, linetype = 8) +
     ggplot2::annotate("text", x = 4, y = incidence + 0.03,
                       label = paste0("Incidence rate: ", percent(incidence))) +
     ggplot2::facet_grid(~names) +


### PR DESCRIPTION
* replaces `ggplot2::aes_string()` (deprecated) with `ggplot2::aes()` and uses the symbolic column names instead of string names
* replaces the deprecated `size` argument in `ggplot2::geom_hline()` with `linewidth`