### PR TITLE
Set future$state to "finished" if API call "succeeded"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: civis
 Title: R Client for the 'Civis Platform API'
-Version: 3.1.0
+Version: 3.1.1
 Authors@R: c(
   person("Peter", "Cooman", email = "pcooman@civisanalytics.com", role = c("cre", "ctb")),
   person("Patrick", "Miller", email = "pmiller@civisanalytics.com", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ License: BSD_3_clause + file LICENSE
 URL: https://github.com/civisanalytics/civis-r
 BugReports: https://github.com/civisanalytics/civis-r/issues
 Imports:
-    future (<= 1.31.0),
+    future (>= 1.8.0),
     httr,
     jsonlite,
     methods,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## [3.1.1]
+
+### Changed
+- As of `future` > 1.31.0, "succeeded" is no longer recognized as a valid state for a
+future. When the Civis API returns a "success" or "succeeded" status, we now map this
+to a "finished" state for `future` objects.
+
 ## [3.1.0]
 
 ### Changed

--- a/tests/testthat/test_civis_future.R
+++ b/tests/testthat/test_civis_future.R
@@ -61,7 +61,7 @@ test_that("run and value work", {
   out <- capture.output(res <- mock_run(quote(2 + 3)))
   expect_equal(res$value, 5)
   expect_equal(res$fut$logs, list("a log"))
-  expect_equal(res$fut$state, "succeeded")
+  expect_equal(res$fut$state, "finished")
   # shouldn't need to be mocked
   expect_equal(value(res$fut), res$val)
 })


### PR DESCRIPTION
New versions of `future` (> 1.31.0) will no longer recognize "succeeded" as a resolved state. This PR sets `future$state` to "finished" if the API job has a "succeeded" status.

See also Issue #245