### PR TITLE
Replace `with_mock` with `local_mocked_bindings` in the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Meta/
 CRAN-SUBMISSION
 cran-comments.md
 .Renviron
+..Rcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 os: linux
 dist: jammy
 language: generic
-# Test this recent and not so recent versions of R.
+# Test this with multiple versions of R.
+# rocker/verse:4.3 is the oldest version for which testthat >= 3.2.0, with local_mocked_bindings, is easily available.
 env:
 - ROCKER_VERSION=4.4
-- ROCKER_VERSION=4.0
+- ROCKER_VERSION=4.3
 services:
   - docker
 before_install:

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Regenerated the default Client (`R/generated_client.R`)
+- Update tests to stop using the deprecated `with_mock()` function. See issue #253.
 
 ## [3.1.2] - 2022-03-30
 

--- a/R/client_base.R
+++ b/R/client_base.R
@@ -40,7 +40,7 @@ call_api <- function(verb, path, path_params, query_params, body_params) {
       # Retry get and put for these error codes, in addition to 429.
       retry_on <- c(413, 429, 502, 503, 504)
       terminate_on <- setdiff(200:527, retry_on)
-      request <- httr::RETRY
+      request <- httr_RETRY
       request_args <- c(request_args, list(terminate_on = terminate_on,
                                            pause_cap = 600,
                                            times = 10))
@@ -50,7 +50,7 @@ call_api <- function(verb, path, path_params, query_params, body_params) {
       request_args <- c(request_args, list(terminate_on = terminate_on,
                                            pause_cap = 600,
                                            times = 10))
-      request <- httr::RETRY
+      request <- httr_RETRY
     }
     response <- do.call(request, request_args)
 
@@ -60,7 +60,7 @@ call_api <- function(verb, path, path_params, query_params, body_params) {
     if (response$status_code %in% c(204, 205)) {
       content <- list()
     } else {
-      content <- try(httr::content(response), silent = TRUE)
+      content <- try(httr_content(response), silent = TRUE)
     }
 
     if (is.error(content)) {
@@ -130,7 +130,7 @@ stop_for_status <- function(x, task = NULL) {
 
   call <- sys.call(-1)
   # e.g. 429, 503 do not have errorDescription fields
-  error_msg <- tryCatch(httr::content(x)$errorDescription,
+  error_msg <- tryCatch(httr_content(x)$errorDescription,
                         error = function(e) "")
   condition <- httr::http_condition(x, "error", task = task, call = call)
   condition$message <- paste0(c(condition$message, error_msg), collapse = " ")

--- a/R/reports.R
+++ b/R/reports.R
@@ -1,3 +1,7 @@
+# Wrap a function for testing purposes.
+# See https://testthat.r-lib.org/reference/local_mocked_bindings.html#namespaced-calls
+rmarkdown_render <- function(...) rmarkdown::render(...)
+
 #' Publish an R Markdown file to Platform Reports
 #'
 #' @param rmd_file string, R Markdown file (.Rmd)
@@ -76,7 +80,7 @@ publish_rmd <- function(rmd_file, report_id=NULL, report_name=NULL,
       render_args[["output_file"]] <- temp_output
     }
     html_args[["html_file"]] <- render_args[["output_file"]]
-    do.call(rmarkdown::render, render_args)
+    do.call(rmarkdown_render, render_args)
     do.call(publish_html, html_args)
   }, finally = {
     unlink(temp_output)
@@ -156,3 +160,7 @@ parse_front_matter <- function(rmd_file) {
   })
   metadata
 }
+
+# Wrap this function for testing purposes.
+# See https://testthat.r-lib.org/reference/local_mocked_bindings.html#namespaced-calls
+readChar <- function(...) base::readChar(...)

--- a/tests/testthat/test_civis_future.R
+++ b/tests/testthat/test_civis_future.R
@@ -1,7 +1,7 @@
 context("civis_future")
 library(civis)
 library(future)
-library(mockery)
+library(testthat)
 
 mock_r_eval <- function(fut) {
   r_remote_eval <- parse(system.file("scripts", "r_remote_eval.R", package = "civis"))
@@ -10,14 +10,14 @@ mock_r_eval <- function(fut) {
   # this deletes the commandArgs lines, which can no longer be mocked.
   r_remote_eval[2:3] <- NULL
 
-  with_mock(
-    `civis::read_civis` = function(...) fut,
-    `civis::scripts_post_containers_runs_outputs` = function(...) NULL,
-    `civis::write_civis_file` = function(...) NULL,
-    eval(r_remote_eval),
-    unlink('r-object.rds'),
-    return(res)
+  local_mocked_bindings(
+    read_civis = function(...) fut,
+    scripts_post_containers_runs_outputs = function(...) NULL,
+    write_civis_file = function(...) NULL
   )
+  eval(r_remote_eval)
+  unlink('r-object.rds')
+  return(res)
 }
 
 test_that("r eval works", {
@@ -44,17 +44,17 @@ test_that("r eval works", {
 
 mock_run <- function(expr) {
   fut <- CivisFuture(expr)
-  with_mock(
-    `civis::write_civis_file` = function(...) 123,
-    `civis::upload_runner_script` = function(...) 1,
-    `civis::scripts_post_containers` = function(...) NULL,
-    `civis::scripts_post_containers_runs` = function(fut) NULL,
-    `civis::scripts_post_containers_runs_outputs` = function(...) NULL,
-    `civis::scripts_get_containers_runs` = function(...) list(state = "succeeded"),
-    `civis::read_civis` = function(...) mock_r_eval(fut),
-    `civis::fetch_logs` = function(...) list("a log"),
-    list(fut = run(fut), value = future::value(fut))
+  local_mocked_bindings(
+    write_civis_file = function(...) 123,
+    upload_runner_script = function(...) 1,
+    scripts_post_containers = function(...) NULL,
+    scripts_post_containers_runs = function(fut) NULL,
+    scripts_post_containers_runs_outputs = function(...) NULL,
+    scripts_get_containers_runs = function(...) list(state = "succeeded"),
+    read_civis = function(...) mock_r_eval(fut),
+    fetch_logs = function(...) list("a log")
   )
+  list(fut = run(fut), value = future::value(fut))
 }
 
 test_that("run and value work", {
@@ -68,17 +68,17 @@ test_that("run and value work", {
 
 mock_err <- function(expr) {
   fut <- CivisFuture(expr)
-  with_mock(
-    `civis::write_civis_file` = function(...) 123,
-    `civis::upload_runner_script` = function(...) 1,
-    `civis::scripts_post_containers` = function(...) NULL,
-    `civis::scripts_post_containers_runs` = function(...) list(containerId = 1, id = 2),
-    `civis::scripts_post_containers_runs_outputs` = function(...) NULL,
-    `civis::scripts_get_containers_runs` = function(id, run_id) list(state = "failed"),
-    `civis::fetch_output` = function(...) NULL,
-    `civis::fetch_logs` = function(...) list("error_log"),
-    list(fut = run(fut), value = future::value(fut))
+  local_mocked_bindings(
+    write_civis_file = function(...) 123,
+    upload_runner_script = function(...) 1,
+    scripts_post_containers = function(...) NULL,
+    scripts_post_containers_runs = function(...) list(containerId = 1, id = 2),
+    scripts_post_containers_runs_outputs = function(...) NULL,
+    scripts_get_containers_runs = function(id, run_id) list(state = "failed"),
+    fetch_output = function(...) NULL,
+    fetch_logs = function(...) list("error_log")
   )
+  list(fut = run(fut), value = future::value(fut))
 }
 
 test_that("run and value handle errors", {
@@ -107,18 +107,18 @@ test_that("CivisFuture has the right stuff", {
 })
 
 test_that("resolved", {
-  with_mock(
-    `civis::scripts_get_containers_runs` = function(...) list(state = "running"),
-    fut <- CivisFuture(quote(2 + 2)),
-    expect_false(resolved(fut))
+  local_mocked_bindings(
+    scripts_get_containers_runs = function(...) list(state = "running")
   )
+  fut <- CivisFuture(quote(2 + 2))
+  expect_false(resolved(fut))
 })
 
 test_that("cancel", {
   fut <- CivisFuture(quote(2 + 2))
-  with_mock(
-    `scripts_delete_containers_runs` = function(...) NULL,
-    cancel(fut)
+  local_mocked_bindings(
+    scripts_delete_containers_runs = function(...) NULL
   )
+  cancel(fut)
   expect_equal(fut$state, "cancelled")
 })

--- a/tests/testthat/test_civis_ml.R
+++ b/tests/testthat/test_civis_ml.R
@@ -24,42 +24,42 @@ test_that("calls scripts_post_custom", {
   fake_scripts_get_custom_runs <- mock(list(state = "running"), list(state = "succeeded"))
   fake_civis_ml_fetch_existing <- mock(NULL)
 
-  with_mock(
-    `civis::get_database_id` = fake_get_database_id,
-    `civis::scripts_post_custom` = fake_scripts_post_custom,
-    `civis::scripts_post_custom_runs` = fake_scripts_post_custom_runs,
-    `civis::scripts_get_custom_runs` = fake_scripts_get_custom_runs,
-    `civis::civis_ml_fetch_existing` = fake_civis_ml_fetch_existing,
-    `civis::get_train_template_id` = function(...) ml_train_template_id,
-
-    tbl <- civis_table(table_name = "schema.table",
-                       database_name = "a_database",
-                       sql_where = "1 = 2",
-                       sql_limit = 10),
-
-    civis_ml(x = tbl,
-             model_type = "sparse_logistic",
-             dependent_variable = "target",
-             excluded_columns = c("col_1", "col_2", "col_3"),
-             primary_key = "row_number",
-             parameters = list(n_estimators = 10),
-             cross_validation_parameters = list(n_estimators = c(10, 20, 30)),
-             model_name = "awesome civisml",
-             calibration = "sigmoid",
-             oos_scores_table = "score.table",
-             oos_scores_db = "another_database",
-             oos_scores_if_exists = "drop",
-             fit_params = list(sample_weight = "survey_weights"),
-             cpu_requested = 1111,
-             memory_requested = 9096,
-             disk_requested = 9,
-             notifications = list(successEmailSubject = "A success",
-                                  successEmailAddresses = c("user@example.com")),
-             polling_interval = .01,
-             validation_data = "skip",
-             n_jobs = 9,
-             verbose = FALSE)
+  local_mocked_bindings(
+    get_database_id = fake_get_database_id,
+    scripts_post_custom = fake_scripts_post_custom,
+    scripts_post_custom_runs = fake_scripts_post_custom_runs,
+    scripts_get_custom_runs = fake_scripts_get_custom_runs,
+    civis_ml_fetch_existing = fake_civis_ml_fetch_existing,
+    get_train_template_id = function(...) ml_train_template_id
   )
+
+  tbl <- civis_table(table_name = "schema.table",
+                      database_name = "a_database",
+                      sql_where = "1 = 2",
+                      sql_limit = 10)
+
+  civis_ml(x = tbl,
+            model_type = "sparse_logistic",
+            dependent_variable = "target",
+            excluded_columns = c("col_1", "col_2", "col_3"),
+            primary_key = "row_number",
+            parameters = list(n_estimators = 10),
+            cross_validation_parameters = list(n_estimators = c(10, 20, 30)),
+            model_name = "awesome civisml",
+            calibration = "sigmoid",
+            oos_scores_table = "score.table",
+            oos_scores_db = "another_database",
+            oos_scores_if_exists = "drop",
+            fit_params = list(sample_weight = "survey_weights"),
+            cpu_requested = 1111,
+            memory_requested = 9096,
+            disk_requested = 9,
+            notifications = list(successEmailSubject = "A success",
+                                 successEmailAddresses = c("user@example.com")),
+            polling_interval = .01,
+            validation_data = "skip",
+            n_jobs = 9,
+            verbose = FALSE)
 
   script_args <- mock_args(fake_scripts_post_custom)[[1]]
   expect_equal(script_args$from_template_id, ml_train_template_id)
@@ -105,60 +105,58 @@ test_that("calls civis_ml.data.frame for local df", {
   fake_get_database_id <- mock(456)
   fake_create_and_run_model <- mock(NULL)
 
-  with_mock(
-    `civis::write_civis_file` = fake_write_civis_file,
-    `civis::get_database_id` = fake_get_database_id,
-    `civis::create_and_run_model` = fake_create_and_run_model,
-    `civis::get_train_template_id` = function(...) ml_train_template_id,
-
-    civis_ml(iris,
-             model_type = "sparse_logistic",
-             dependent_variable = "the_target_column",
-             primary_key = "the_pk_column"),
-
-    expect_args(fake_create_and_run_model, 1,
-                file_id = 1234,
-                dependent_variable = "the_target_column",
-                excluded_columns = NULL,
-                primary_key = "the_pk_column",
-                model_type = "sparse_logistic",
-                parameters = NULL,
-                cross_validation_parameters = NULL,
-                fit_params = NULL,
-                calibration = NULL,
-                oos_scores_table = NULL,
-                oos_scores_db_id = NULL,
-                oos_scores_if_exists = 'fail',
-                model_name = NULL,
-                cpu_requested = NULL,
-                memory_requested = NULL,
-                disk_requested = NULL,
-                validation_data = 'train',
-                n_jobs = NULL,
-                notifications = NULL,
-                verbose = FALSE,
-                civisml_version = "prod")
+  local_mocked_bindings(
+    write_civis_file = fake_write_civis_file,
+    get_database_id = fake_get_database_id,
+    create_and_run_model = fake_create_and_run_model,
+    get_train_template_id = function(...) ml_train_template_id
   )
+  civis_ml(iris,
+           model_type = "sparse_logistic",
+           dependent_variable = "the_target_column",
+           primary_key = "the_pk_column")
+
+  expect_args(fake_create_and_run_model, 1,
+              file_id = 1234,
+              dependent_variable = "the_target_column",
+              excluded_columns = NULL,
+              primary_key = "the_pk_column",
+              model_type = "sparse_logistic",
+              parameters = NULL,
+              cross_validation_parameters = NULL,
+              fit_params = NULL,
+              calibration = NULL,
+              oos_scores_table = NULL,
+              oos_scores_db_id = NULL,
+              oos_scores_if_exists = 'fail',
+              model_name = NULL,
+              cpu_requested = NULL,
+              memory_requested = NULL,
+              disk_requested = NULL,
+              validation_data = 'train',
+              n_jobs = NULL,
+              notifications = NULL,
+              verbose = FALSE,
+              civisml_version = "prod")
 })
 
 test_that("calls civis_ml.civis_table for table_name", {
   fake_get_database_id <- mock(456)
   fake_create_and_run_model <- mock(NULL)
 
-  with_mock(
-    `civis::get_database_id` = fake_get_database_id,
-    `civis::create_and_run_model` = fake_create_and_run_model,
-
-    x <- civis_table(table_name = "a_schema.table",
-                     database_name = "a_database",
-                     sql_where = "a = b",
-                     sql_limit = 6),
-
-    civis_ml(x = x,
-             model_type = "sparse_logistic",
-             dependent_variable = "the_target_column",
-             primary_key = "the_pk_column")
+  local_mocked_bindings(
+    get_database_id = fake_get_database_id,
+    create_and_run_model = fake_create_and_run_model
   )
+  x <- civis_table(table_name = "a_schema.table",
+                   database_name = "a_database",
+                   sql_where = "a = b",
+                   sql_limit = 6)
+
+  civis_ml(x = x,
+           model_type = "sparse_logistic",
+           dependent_variable = "the_target_column",
+           primary_key = "the_pk_column")
 
   expect_args(fake_get_database_id, 1, "a_database")
 
@@ -193,15 +191,15 @@ test_that("calls civis_ml.civis_file for file_id", {
   fake_get_database_id <- mock(456)
   fake_create_and_run_model <- mock(NULL)
 
-  with_mock(
-    `civis::get_database_id` = fake_get_database_id,
-    `civis::create_and_run_model` = fake_create_and_run_model,
-
-    civis_ml(x = civis_file(file_id = 123),
-             model_type = "sparse_logistic",
-             dependent_variable = "the_target_column",
-             primary_key = "the_pk_column")
+  local_mocked_bindings(
+    get_database_id = fake_get_database_id,
+    create_and_run_model = fake_create_and_run_model
   )
+
+  civis_ml(x = civis_file(file_id = 123),
+           model_type = "sparse_logistic",
+           dependent_variable = "the_target_column",
+           primary_key = "the_pk_column")
 
   expect_args(fake_create_and_run_model, 1,
               file_id = civis_file(123),
@@ -232,16 +230,16 @@ test_that("calls civis_ml.character for local csv", {
   fake_write_civis_file <- mock(123)
   fake_create_and_run_model <- mock(NULL)
 
-  with_mock(
-    `civis::get_database_id` = fake_get_database_id,
-    `civis::write_civis_file` = fake_write_civis_file,
-    `civis::create_and_run_model` = fake_create_and_run_model,
-
-    civis_ml(x =  "fake_temp_path",
-             model_type = "sparse_logistic",
-             dependent_variable = "the_target_column",
-             primary_key = "the_pk_column")
+  local_mocked_bindings(
+    get_database_id = fake_get_database_id,
+    write_civis_file = fake_write_civis_file,
+    create_and_run_model = fake_create_and_run_model
   )
+
+  civis_ml(x =  "fake_temp_path",
+           model_type = "sparse_logistic",
+           dependent_variable = "the_target_column",
+           primary_key = "the_pk_column")
 
   expect_args(fake_write_civis_file, 1,
               path = "fake_temp_path",
@@ -275,17 +273,17 @@ test_that("raises error on invalid calibration", {
   fake_get_database_id <- mock(456)
   fake_write_civis_file <- mock(123)
 
-  with_mock(
-    `civis::get_database_id` = fake_get_database_id,
-    `civis::write_civis_file` = fake_write_civis_file,
-
-    expect_error(civis_ml(x = "fake_temp_path",
-                          model_type = "sparse_logistic",
-                          dependent_variable = "target",
-                          primary_key = "pk",
-                          calibration = "fake"),
-                 "calibration must be 'sigmoid', 'isotonic', or NULL\\.")
+  local_mocked_bindings(
+    get_database_id = fake_get_database_id,
+    write_civis_file = fake_write_civis_file
   )
+
+  expect_error(civis_ml(x = "fake_temp_path",
+                        model_type = "sparse_logistic",
+                        dependent_variable = "target",
+                        primary_key = "pk",
+                        calibration = "fake"),
+               "calibration must be 'sigmoid', 'isotonic', or NULL\\.")
 })
 
 test_that("raises error if multioutput not supported", {
@@ -295,17 +293,17 @@ test_that("raises error if multioutput not supported", {
     "sparse_logistic", "gradient_boosting_classifier")
 
   for (mtype in mo_not_supported) {
-    with_mock(
-      `civis::get_database_id` = fake_get_database_id,
-      `civis::write_civis_file` = fake_write_civis_file,
-
-      expect_error(civis_ml(x = "fake_temp_path",
-                            model_type = mtype,
-                            dependent_variable = c("target", "target_2"),
-                            primary_key = "pk",
-                            calibration = "fake"),
-                   paste0("Multioutput is not supported for ", mtype))
+    local_mocked_bindings(
+      get_database_id = fake_get_database_id,
+      write_civis_file = fake_write_civis_file
     )
+    expect_error(civis_ml(x = "fake_temp_path",
+              model_type = mtype,
+              dependent_variable = c("target", "target_2"),
+              primary_key = "pk",
+              calibration = "fake"),
+            paste0("Multioutput is not supported for ", mtype))
+
   }
 })
 
@@ -336,32 +334,32 @@ test_that("calls scripts_post_custom", {
   fake_scripts_get_custom <- mock(list(state = "succeeded"), cycle = TRUE)
   fake_fetch_predict_results <- mock(NULL)
 
-  with_mock(
-    `civis::get_database_id` = fake_get_database_id,
-    `civis::scripts_post_custom` = fake_scripts_post_custom,
-    `civis::scripts_post_custom_runs` = fake_scripts_post_custom_runs,
-    `civis::scripts_get_custom` = fake_scripts_get_custom,
-    `civis::scripts_get_custom_runs` = fake_scripts_get_custom_runs,
-    `civis::fetch_predict_results` = fake_fetch_predict_results,
-    `civis::get_predict_template_id` = function(...) ml_predict_template_id,
-
-    tbl <- civis_table(table_name = "schema.table",
-                       database_name = "a_database",
-                       sql_where = "6 = 7",
-                       sql_limit = 7),
-    predict(fake_model,
-            newdata = tbl,
-            primary_key = "row_number",
-            output_table = "score.table",
-            output_db = "score_database",
-            if_output_exists = "append",
-            n_jobs = 10,
-            cpu_requested = 2000,
-            memory_requested = 10,
-            disk_requested = 15,
-            polling_interval = .01,
-            verbose = TRUE)
+  local_mocked_bindings(
+    get_database_id = fake_get_database_id,
+    scripts_post_custom = fake_scripts_post_custom,
+    scripts_post_custom_runs = fake_scripts_post_custom_runs,
+    scripts_get_custom = fake_scripts_get_custom,
+    scripts_get_custom_runs = fake_scripts_get_custom_runs,
+    fetch_predict_results = fake_fetch_predict_results,
+    get_predict_template_id = function(...) ml_predict_template_id
   )
+
+  tbl <- civis_table(table_name = "schema.table",
+                     database_name = "a_database",
+                     sql_where = "6 = 7",
+                     sql_limit = 7)
+  predict(fake_model,
+          newdata = tbl,
+          primary_key = "row_number",
+          output_table = "score.table",
+          output_db = "score_database",
+          if_output_exists = "append",
+          n_jobs = 10,
+          cpu_requested = 2000,
+          memory_requested = 10,
+          disk_requested = 15,
+          polling_interval = .01,
+          verbose = TRUE)
 
   script_args <- mock_args(fake_scripts_post_custom)[[1]]
   expect_equal(script_args$from_template_id, ml_predict_template_id)
@@ -399,14 +397,14 @@ test_that("uses training primary_key by default", {
   fake_get_database_id <- mock(123)
   fake_create_and_run_pred <- mock(NULL)
 
-  with_mock(
-    `civis::get_database_id` = fake_get_database_id,
-    `civis::create_and_run_pred` = fake_create_and_run_pred,
-    `civis::get_predict_template_id` = function(...) ml_predict_template_id,
-
-    tbl <- civis_table(table_name = "schema.table", database_name = "the_db"),
-    predict(fake_model, newdata = tbl)
+  local_mocked_bindings(
+    get_database_id = fake_get_database_id,
+    create_and_run_pred = fake_create_and_run_pred,
+    get_predict_template_id = function(...) ml_predict_template_id
   )
+
+  tbl <- civis_table(table_name = "schema.table", database_name = "the_db")
+  predict(fake_model, newdata = tbl)
 
   run_args <- mock_args(fake_create_and_run_pred)[[1]]
   expect_equal(run_args$primary_key, "training_primary_key")
@@ -416,13 +414,13 @@ test_that("uploads local df and passes a file_id", {
   fake_write_civis_file <- mock(1234)
   fake_create_and_run_pred <- mock(NULL)
 
-  with_mock(
-    `civis::write_civis_file` = fake_write_civis_file,
-    `civis::create_and_run_pred` = fake_create_and_run_pred,
-    `civis::get_predict_template_id` = function(...) ml_predict_template_id,
-
-    predict(fake_model, iris, primary_key = NULL)
+  local_mocked_bindings(
+    write_civis_file = fake_write_civis_file,
+    create_and_run_pred = fake_create_and_run_pred,
+    get_predict_template_id = function(...) ml_predict_template_id
   )
+
+  predict(fake_model, iris, primary_key = NULL)
 
   expect_args(fake_create_and_run_pred, 1,
               train_job_id = fake_model$job$id,
@@ -446,13 +444,13 @@ test_that("uploads a local file and passes a file_id", {
   fake_write_civis_file <- mock(561)
   fake_create_and_run_pred <- mock(NULL)
 
-  with_mock(
-    `civis::write_civis_file` = fake_write_civis_file,
-    `civis::create_and_run_pred` = fake_create_and_run_pred,
-    `civis::get_predict_template_id` = function(...) ml_predict_template_id,
-
-    predict(fake_model, "fake_temp_path", primary_key = NULL)
+  local_mocked_bindings(
+    write_civis_file = fake_write_civis_file,
+    create_and_run_pred = fake_create_and_run_pred,
+    get_predict_template_id = function(...) ml_predict_template_id
   )
+
+  predict(fake_model, "fake_temp_path", primary_key = NULL)
 
   expect_args(fake_write_civis_file, 1,
               "fake_temp_path",
@@ -479,12 +477,12 @@ test_that("uploads a local file and passes a file_id", {
 test_that("passes a file_id directly", {
   fake_create_and_run_pred <- mock(NULL)
 
-  with_mock(
-    `civis::create_and_run_pred` = fake_create_and_run_pred,
-    `civis::get_predict_template_id` = function(...) ml_predict_template_id,
-
-    predict(fake_model, civis_file(1234))
+  local_mocked_bindings(
+    create_and_run_pred = fake_create_and_run_pred,
+    get_predict_template_id = function(...) ml_predict_template_id
   )
+
+  predict(fake_model, civis_file(1234))
 
   expect_args(fake_create_and_run_pred, 1,
               train_job_id = fake_model$job$id,
@@ -507,13 +505,12 @@ test_that("passes a file_id directly", {
 test_that("passes a manifest file_id", {
   fake_create_and_run_pred <- mock(NULL)
 
-  with_mock(
-    `civis::create_and_run_pred` = fake_create_and_run_pred,
-    `civis::get_predict_template_id` = function(...) ml_predict_template_id,
-
-
-    predict(fake_model, civis_file_manifest(123), primary_key = NULL)
+  local_mocked_bindings(
+    create_and_run_pred = fake_create_and_run_pred,
+    get_predict_template_id = function(...) ml_predict_template_id
   )
+
+  predict(fake_model, civis_file_manifest(123), primary_key = NULL)
 
   expect_args(fake_create_and_run_pred, 1,
               train_job_id = fake_model$job$id,
@@ -537,19 +534,19 @@ test_that("passes table info", {
   fake_get_database_id <- mock(999)
   fake_create_and_run_pred <- mock(NULL)
 
-  with_mock(
-    `civis::get_database_id` = fake_get_database_id,
-    `civis::create_and_run_pred` = fake_create_and_run_pred,
-    `civis::get_predict_template_id` = function(...) ml_predict_template_id,
-
-    table_to_score <- civis_table(
-      table_name = "a_schema.table",
-      database_name = "a_database",
-      sql_where = "row_number in (1, 2, 4)",
-      sql_limit = 11
-    ),
-    predict(fake_model, table_to_score, primary_key = NULL)
+  local_mocked_bindings(
+    get_database_id = fake_get_database_id,
+    create_and_run_pred = fake_create_and_run_pred,
+    get_predict_template_id = function(...) ml_predict_template_id
   )
+
+  table_to_score <- civis_table(
+    table_name = "a_schema.table",
+    database_name = "a_database",
+    sql_where = "row_number in (1, 2, 4)",
+    sql_limit = 11
+  )
+  predict(fake_model, table_to_score, primary_key = NULL)
 
   expect_args(fake_get_database_id, 1, "a_database")
   expect_args(fake_create_and_run_pred, 1,
@@ -582,14 +579,12 @@ test_that("newer CivisML versions use feather", {
   # factor should not cause errors when using feather
   x <- data.frame(a = 1:3, b = letters[1:3])
   fake_file <- mock(1)
-  with_mock(
-    `civis::write_civis_file` = fake_file,
-    {
-      stash_local_dataframe(x, temp_id)
-      args <- mock_args(fake_file)
-      expect_equal(args[[1]]$name, "modelpipeline_data.feather")
-    }
+  local_mocked_bindings(
+    write_civis_file = fake_file
   )
+  stash_local_dataframe(x, temp_id)
+  args <- mock_args(fake_file)
+  expect_equal(args[[1]]$name, "modelpipeline_data.feather")
 
 })
 
@@ -599,14 +594,12 @@ test_that("older CivisML versions use csv", {
   # factor type should not matter for older version
   x <- data.frame(a = 1:3, b = letters[1:3], stringsAsFactors = FALSE)
   fake_file <- mock(1)
-  with_mock(
-    `civis::write_civis_file` = fake_file,
-    {
-      stash_local_dataframe(x, temp_id)
-      args <- mock_args(fake_file)
-      expect_equal(args[[1]]$name, "modelpipeline_data.csv")
-    }
+  local_mocked_bindings(
+    write_civis_file = fake_file
   )
+  stash_local_dataframe(x, temp_id)
+  args <- mock_args(fake_file)
+  expect_equal(args[[1]]$name, "modelpipeline_data.csv")
 })
 
 ################################################################################
@@ -617,13 +610,13 @@ test_that("uses the correct template_id", {
   fake_run_model <- mock(list(job_id = 133, run_id = 244))
   fake_civis_ml_fetch_existing <- mock(NULL)
 
-  with_mock(
-    `civis::run_model` = fake_run_model,
-    `civis::civis_ml_fetch_existing` = fake_civis_ml_fetch_existing,
-    `civis::get_train_template_id` = function(...) ml_train_template_id,
-
-    create_and_run_model(file_id = 123)
+  local_mocked_bindings(
+    run_model = fake_run_model,
+    civis_ml_fetch_existing = fake_civis_ml_fetch_existing,
+    get_train_template_id = function(...) ml_train_template_id
   )
+
+  create_and_run_model(file_id = 123)
 
   run_args <- mock_args(fake_run_model)[[1]]
   expect_equal(run_args$template_id, ml_train_template_id)
@@ -633,13 +626,13 @@ test_that("converts parameters arg to JSON string", {
   fake_run_model <- mock(list(job_id = 133, run_id = 244))
   fake_civis_ml_fetch_existing <- mock(NULL)
 
-  with_mock(
-    `civis::run_model` = fake_run_model,
-    `civis::civis_ml_fetch_existing` = fake_civis_ml_fetch_existing,
-    `civis::get_train_template_id` = function(...) ml_train_template_id,
-
-    create_and_run_model(file_id = 123, parameters = list(n_trees = 500, c = -1))
+  local_mocked_bindings(
+    run_model = fake_run_model,
+    civis_ml_fetch_existing = fake_civis_ml_fetch_existing,
+    get_train_template_id = function(...) ml_train_template_id
   )
+
+  create_and_run_model(file_id = 123, parameters = list(n_trees = 500, c = -1))
 
   run_args <- mock_args(fake_run_model)[[1]]
   expect_equal(unclass(run_args$arguments$PARAMS), '{"n_trees":500,"c":-1}')
@@ -649,15 +642,15 @@ test_that("converts cross_validation_parameters to JSON string", {
   fake_run_model <- mock(list(job_id = 133, run_id = 244))
   fake_civis_ml_fetch_existing <- mock(NULL)
 
-  with_mock(
-    `civis::run_model` = fake_run_model,
-    `civis::civis_ml_fetch_existing` = fake_civis_ml_fetch_existing,
-    `civis::get_train_template_id` = function(...) ml_train_template_id,
-
-    create_and_run_model(file_id = 123,
-                         model_type = "sparse_logistic",
-                         cross_validation_parameters = list(n_trees = c(500, 250), c = -1))
+  local_mocked_bindings(
+    run_model = fake_run_model,
+    civis_ml_fetch_existing = fake_civis_ml_fetch_existing,
+    get_train_template_id = function(...) ml_train_template_id
   )
+
+  create_and_run_model(file_id = 123,
+                        model_type = "sparse_logistic",
+                        cross_validation_parameters = list(n_trees = c(500, 250), c = -1))
 
   run_args <- mock_args(fake_run_model)[[1]]
   expect_equal(unclass(run_args$arguments$CVPARAMS),
@@ -668,14 +661,14 @@ test_that("converts fit_params to JSON string", {
   fake_run_model <- mock(list(job_id = 133, run_id = 244))
   fake_civis_ml_fetch_existing <- mock(NULL)
 
-  with_mock(
-    `civis::run_model` = fake_run_model,
-    `civis::civis_ml_fetch_existing` = fake_civis_ml_fetch_existing,
-    `civis::get_train_template_id` = function(...) ml_train_template_id,
-
-    create_and_run_model(file_id = 123,
-                         fit_params = list(weights = "weight_col"))
+  local_mocked_bindings(
+    run_model = fake_run_model,
+    civis_ml_fetch_existing = fake_civis_ml_fetch_existing,
+    get_train_template_id = function(...) ml_train_template_id
   )
+
+  create_and_run_model(file_id = 123,
+                       fit_params = list(weights = "weight_col"))
 
   run_args <- mock_args(fake_run_model)[[1]]
   expect_equal(unclass(run_args$arguments$FIT_PARAMS), '{"weights":"weight_col"}')
@@ -685,13 +678,13 @@ test_that("space separates excluded_columns", {
   fake_run_model <- mock(list(job_id = 133, run_id = 244))
   fake_civis_ml_fetch_existing <- mock(NULL)
 
-  with_mock(
-    `civis::run_model` = fake_run_model,
-    `civis::civis_ml_fetch_existing` = fake_civis_ml_fetch_existing,
-    `civis::get_train_template_id` = function(...) ml_train_template_id,
-
-    create_and_run_model(file_id = 132, excluded_columns = c("c1", "c2", "c3"))
+  local_mocked_bindings(
+    run_model = fake_run_model,
+    civis_ml_fetch_existing = fake_civis_ml_fetch_existing,
+    get_train_template_id = function(...) ml_train_template_id
   )
+
+  create_and_run_model(file_id = 132, excluded_columns = c("c1", "c2", "c3"))
 
   run_args <- mock_args(fake_run_model)[[1]]
   expect_equal(run_args$arguments$EXCLUDE_COLS, "c1 c2 c3")
@@ -701,14 +694,14 @@ test_that("space separates target_column", {
   fake_run_model <- mock(list(job_id = 133, run_id = 244))
   fake_civis_ml_fetch_existing <- mock(NULL)
 
-  with_mock(
-    `civis::run_model` = fake_run_model,
-    `civis::civis_ml_fetch_existing` = fake_civis_ml_fetch_existing,
-    `civis::get_train_template_id` = function(...) ml_train_template_id,
-
-    create_and_run_model(file_id = 132, dependent_variable = c("c1", "c2"),
-                         model_type = "random_forest_regressor")
+  local_mocked_bindings(
+    run_model = fake_run_model,
+    civis_ml_fetch_existing = fake_civis_ml_fetch_existing,
+    get_train_template_id = function(...) ml_train_template_id
   )
+
+  create_and_run_model(file_id = 132, dependent_variable = c("c1", "c2"),
+                       model_type = "random_forest_regressor")
 
   run_args <- mock_args(fake_run_model)[[1]]
   expect_equal(run_args$arguments$TARGET_COLUMN, "c1 c2")
@@ -718,13 +711,13 @@ test_that("file_id is always numeric", {
   fake_run_model <- mock(list(job_id = 133, run_id = 244))
   fake_civis_ml_fetch_existing <- mock(NULL)
 
-  with_mock(
-    `civis::run_model` = fake_run_model,
-    `civis::civis_ml_fetch_existing` = fake_civis_ml_fetch_existing,
-    `civis::get_train_template_id` = function(...) ml_train_template_id,
-
-    create_and_run_model(file_id = civis_file(132))
+  local_mocked_bindings(
+    run_model = fake_run_model,
+    civis_ml_fetch_existing = fake_civis_ml_fetch_existing,
+    get_train_template_id = function(...) ml_train_template_id
   )
+
+  create_and_run_model(file_id = civis_file(132))
 
   run_args <- mock_args(fake_run_model)[[1]]
   expect_equal(run_args$arguments$CIVIS_FILE_ID, 132)
@@ -734,14 +727,14 @@ test_that("exceptions with hyperband correct", {
   fake_run_model <- mock(list(job_id = 133, run_id = 244))
   fake_civis_ml_fetch_existing <- mock(NULL)
 
-  with_mock(
-    `civis::run_model` = fake_run_model,
-    `civis::civis_ml_fetch_existing` = fake_civis_ml_fetch_existing,
-    err <-  "cross_validation_parameters = \"hyperband\" not supported for sparse_logistic",
-    expect_error(create_and_run_model(file_id = civis_file(132),
-                                      model_type = "sparse_logistic",
-                                      cross_validation_parameters = "hyperband"), err)
+  local_mocked_bindings(
+    run_model = fake_run_model,
+    civis_ml_fetch_existing = fake_civis_ml_fetch_existing
   )
+  err <- "cross_validation_parameters = \"hyperband\" not supported for sparse_logistic"
+  expect_error(create_and_run_model(file_id = civis_file(132),
+                                    model_type = "sparse_logistic",
+                                    cross_validation_parameters = "hyperband"), err)
 })
 
 test_that("robust if metrics.json not present", {
@@ -753,14 +746,14 @@ test_that("robust if metrics.json not present", {
   fake_fetch_job <- mock(1)
   fake_fetch_run <- mock(list(state = "succeeded"))
   fake_model_type <- mock("regressor")
-  res <- with_mock(
-    `civis::must_fetch_civis_ml_job` = fake_fetch_job,
-    `civis::must_fetch_civis_ml_run` = fake_fetch_run,
-    `civis::scripts_list_custom_runs_outputs` = fake_outputs,
-    `civis::download_civis` = fake_download,
-    `civis::model_type` = fake_model_type,
-    civis_ml_fetch_existing(123, 1)
+  local_mocked_bindings(
+    must_fetch_civis_ml_job = fake_fetch_job,
+    must_fetch_civis_ml_run = fake_fetch_run,
+    scripts_list_custom_runs_outputs = fake_outputs,
+    download_civis = fake_download,
+    model_type = fake_model_type
   )
+  res <- civis_ml_fetch_existing(123, 1)
   expect_equal(res$model_info, list(a=1, b=letters[1:3]))
   expect_null(res$metrics)
 })
@@ -775,14 +768,14 @@ test_that("uses the correct template_id", {
   fake_run_model <- mock(list(job_id = 133, run_id = 244))
   fake_fetch_predict_results <- mock(NULL)
 
-  with_mock(
-    `civis::run_model` = fake_run_model,
-    `civis::fetch_predict_results` = fake_fetch_predict_results,
-
-    create_and_run_pred(train_job_id = 111, train_run_id = 222, template_id = 555),
-    run_args <- mock_args(fake_run_model)[[1]],
-    expect_equal(run_args$template_id, 555)
+  local_mocked_bindings(
+    run_model = fake_run_model,
+    fetch_predict_results = fake_fetch_predict_results
   )
+
+  create_and_run_pred(train_job_id = 111, train_run_id = 222, template_id = 555)
+  run_args <- mock_args(fake_run_model)[[1]]
+  expect_equal(run_args$template_id, 555)
 })
 
 ################################################################################
@@ -792,11 +785,10 @@ context("civis_ml_fetch_existing")
 test_that("raises an error on not found", {
   fake_scripts_get_custom <- function(id) stop(httr::http_condition(404L, "error"))
 
-  with_mock(
-    `civis::scripts_get_custom` = fake_scripts_get_custom,
-
-    expect_error(civis_ml_fetch_existing(123), "Error: model 123 not found\\.")
+  local_mocked_bindings(
+    scripts_get_custom = fake_scripts_get_custom
   )
+  expect_error(civis_ml_fetch_existing(123), "Error: model 123 not found\\.")
 })
 
 test_that("raises an error on invalid model", {
@@ -807,11 +799,10 @@ test_that("raises an error on invalid model", {
       )
     )
   )
-  with_mock(
-    `civis::must_fetch_civis_ml_job` = fake_must_fetch_civis_ml_job,
-
-    expect_error(civis_ml_fetch_existing(123), "Error: invalid model task\\.")
+  local_mocked_bindings(
+    must_fetch_civis_ml_job = fake_must_fetch_civis_ml_job
   )
+  expect_error(civis_ml_fetch_existing(123), "Error: invalid model task\\.")
 })
 
 test_that("issues message for still running", {
@@ -827,13 +818,12 @@ test_that("issues message for still running", {
   )
   fake_scripts_get_custom_runs <- mock(list(state = "running"))
 
-  with_mock(
-    `civis::must_fetch_civis_ml_job` = fake_must_fetch_civis_ml_job,
-    `civis::scripts_get_custom_runs` = fake_scripts_get_custom_runs,
-
-    expect_message(civis_ml_fetch_existing(123),
-                   "The model task is still running\\.")
+  local_mocked_bindings(
+    must_fetch_civis_ml_job = fake_must_fetch_civis_ml_job,
+    scripts_get_custom_runs = fake_scripts_get_custom_runs
   )
+  expect_message(civis_ml_fetch_existing(123),
+                 "The model task is still running\\.")
 })
 
 test_that("raises an error if job failed", {
@@ -849,26 +839,26 @@ test_that("raises an error if job failed", {
   )
   fake_scripts_get_custom_runs <- mock(list(state = "failed"))
 
-  with_mock(
-    `civis::must_fetch_civis_ml_job` = fake_must_fetch_civis_ml_job,
-    `civis::scripts_get_custom_runs` = fake_scripts_get_custom_runs,
-
-    expect_warning(civis_ml_fetch_existing(123),
-                   "The model task failed, use fetch_logs to retreive any error messages.")
+  local_mocked_bindings(
+    must_fetch_civis_ml_job = fake_must_fetch_civis_ml_job,
+    scripts_get_custom_runs = fake_scripts_get_custom_runs
   )
+  expect_warning(civis_ml_fetch_existing(123),
+                 "The model task failed, use fetch_logs to retreive any error messages.")
 })
 
 test_that("fetch_logs.civis_ml_error works", {
-  with_mock(
-    `civis::scripts_post_custom` = function(...) NULL,
-    `civis::scripts_post_custom_runs` = function(...) NULL,
-    `civis::scripts_get_custom_runs` = function(...) list(state = "failed", id = 1, run_id = 2, error = "msg"),
-    `civis::fetch_logs.civis_ml_error` = function(...) list("A log message"),
-    e <- tryCatch(civis:::run_model(1234, name = "sparse_logistic", list(), list(),
-                                    verbose = TRUE, polling_interval = NULL),
-             error = function(e) e),
-    log <- fetch_logs(e)[[1]],
-    expect_equal(log, "A log message"))
+  local_mocked_bindings(
+    scripts_post_custom = function(...) NULL,
+    scripts_post_custom_runs = function(...) NULL,
+    scripts_get_custom_runs = function(...) list(state = "failed", id = 1, run_id = 2, error = "msg"),
+    fetch_logs.civis_ml_error = function(...) list("A log message")
+  )
+  e <- tryCatch(civis:::run_model(1234, name = "sparse_logistic", list(), list(),
+                                  verbose = TRUE, polling_interval = NULL),
+            error = function(e) e)
+  log <- fetch_logs(e)[[1]]
+  expect_equal(log, "A log message")
 })
 
 ###############################################################################
@@ -879,14 +869,13 @@ test_that("it removes notifications when NULL", {
   fake_scripts_post_custom_runs <- mock(list(id = 456))
   fake_scripts_get_custom_runs <- mock(list(state = "succeeded"))
 
-  with_mock(
-    `civis::scripts_post_custom` = fake_scripts_post_custom,
-    `civis::scripts_post_custom_runs` = fake_scripts_post_custom_runs,
-    `civis::scripts_get_custom_runs` = fake_scripts_get_custom_runs,
-
-    run_model(template_id = 123, name = "a name", arguments = list(a = "b"),
-              notifications = NULL, verbose = TRUE)
+  local_mocked_bindings(
+    scripts_post_custom = fake_scripts_post_custom,
+    scripts_post_custom_runs = fake_scripts_post_custom_runs,
+    scripts_get_custom_runs = fake_scripts_get_custom_runs
   )
+  run_model(template_id = 123, name = "a name", arguments = list(a = "b"),
+            notifications = NULL, verbose = TRUE)
   script_args <- mock_args(fake_scripts_post_custom)[[1]]
   expect_false("notifications" %in% names(script_args))
 })
@@ -896,26 +885,26 @@ test_that("it removes name when NULL", {
   fake_scripts_post_custom_runs <- mock(list(id = 456))
   fake_scripts_get_custom_runs <- mock(list(state = "succeeded", NULL))
 
-  with_mock(
-    `civis::scripts_post_custom` = fake_scripts_post_custom,
-    `civis::scripts_post_custom_runs` = fake_scripts_post_custom_runs,
-    `civis::scripts_get_custom_runs` = fake_scripts_get_custom_runs,
-
-    run_model(template_id = 123, name = NULL, arguments = list(a = "b"),
-              notifications = NULL, verbose = TRUE)
+  local_mocked_bindings(
+    scripts_post_custom = fake_scripts_post_custom,
+    scripts_post_custom_runs = fake_scripts_post_custom_runs,
+    scripts_get_custom_runs = fake_scripts_get_custom_runs
   )
+  run_model(template_id = 123, name = NULL, arguments = list(a = "b"),
+            notifications = NULL, verbose = TRUE)
   script_args <- mock_args(fake_scripts_post_custom)[[1]]
   expect_false("name" %in% names(script_args))
 })
 
 test_that("civis_ml_error is caught from run_model", {
-  e <- with_mock(
-    `civis::scripts_post_custom` = function(...) NULL,
-    `civis::scripts_post_custom_runs` = function(...) NULL,
-    `civis::scripts_get_custom_runs` = function(...) list(state = "failed", id = 1, run_id = 2, error = "msg"),
-    `civis::fetch_logs.civis_ml_error` = function(...) list("A log message"),
-    tryCatch(civis:::run_model(1234, name = "sparse_logistic", list(), list(), verbose = TRUE),
-             error = function(e) e))
+  local_mocked_bindings(
+    scripts_post_custom = function(...) NULL,
+    scripts_post_custom_runs = function(...) NULL,
+    scripts_get_custom_runs = function(...) list(state = "failed", id = 1, run_id = 2, error = "msg"),
+    fetch_logs.civis_ml_error = function(...) list("A log message")
+  )
+  e <- tryCatch(civis:::run_model(1234, name = "sparse_logistic", list(), list(), verbose = TRUE),
+                error = function(e) e)
   msg <- "scripts_get_custom_runs(... = NULL, run_id = NULL): msg\nA log message"
   expect_equal(e$message, msg)
   expect_is(e, c("civis_ml_error", "civis_error"))
@@ -932,20 +921,19 @@ context("fetch_oos_scores")
 test_that("it checks input type", {
   fake_must_fetch_output_file <- mock(NULL)
 
-  with_mock(
-    `civis::must_fetch_output_file` = fake_must_fetch_output_file,
-    expect_error(fetch_oos_scores("not a model"), "is_civis_ml(model) is not TRUE", fixed = TRUE)
+  local_mocked_bindings(
+    must_fetch_output_file = fake_must_fetch_output_file
   )
+  expect_error(fetch_oos_scores("not a model"), "is_civis_ml(model) is not TRUE", fixed = TRUE)
 })
 
 test_that("it looks for predictions.csv.gz", {
   fake_must_fetch_output_file <- mock(textConnection(c("a, b, c")))
 
-  with_mock(
-    `civis::must_fetch_output_file` = fake_must_fetch_output_file,
-    fetch_oos_scores(structure(list(), class = "civis_ml"))
+  local_mocked_bindings(
+    must_fetch_output_file = fake_must_fetch_output_file
   )
-
+  fetch_oos_scores(structure(list(), class = "civis_ml"))
   fetch_args <- mock_args(fake_must_fetch_output_file)[[1]]
   expect_equal(fetch_args[[2]], "predictions.csv.gz")
 })
@@ -953,11 +941,11 @@ test_that("it looks for predictions.csv.gz", {
 test_that("it calls read.csv with extra args", {
   fake_must_fetch_output_file <- mock(textConnection(c("a,b,c")))
 
-  df <- with_mock(
-    `civis::must_fetch_output_file` = fake_must_fetch_output_file,
-    fetch_oos_scores(structure(list(), class = "civis_ml"),
-                           stringsAsFactors = FALSE, header = FALSE)
+  local_mocked_bindings(
+    must_fetch_output_file = fake_must_fetch_output_file
   )
+  df <- fetch_oos_scores(structure(list(), class = "civis_ml"),
+                         stringsAsFactors = FALSE, header = FALSE)
   ans <- data.frame(V1 = "a", V2 = "b", V3 = "c", stringsAsFactors = FALSE)
   expect_equal(df, ans)
 })
@@ -974,12 +962,12 @@ test_that("it calls read.csv with extra args, and dowload_civis with correct id"
   fake_read_csv <- mock(NULL)
   fake_download_civis <- mock(textConnection(c("a,b,c")))
 
-  df <- with_mock(
-    `civis::fetch_predict_results` = function(...) list(model_info = list(output_file_ids = 1)),
-    `civis::download_civis` = fake_download_civis,
-    fetch_predictions(structure(list(), class = "civis_ml_prediction"),
-                      header = FALSE, stringsAsFactors = FALSE)
+  local_mocked_bindings(
+    fetch_predict_results = function(...) list(model_info = list(output_file_ids = 1)),
+    download_civis = fake_download_civis
   )
+  df <- fetch_predictions(structure(list(), class = "civis_ml_prediction"),
+                      header = FALSE, stringsAsFactors = FALSE)
   ans <- data.frame(V1 = "a", V2 = "b", V3 = "c", stringsAsFactors = FALSE)
   expect_equal(df, ans)
 

--- a/tests/testthat/test_civis_ml_utils.R
+++ b/tests/testthat/test_civis_ml_utils.R
@@ -1,4 +1,5 @@
 library(civis)
+library(testthat)
 context("civis_ml_utils")
 
 model_list <- readRDS("data/civis_ml_models.rds")
@@ -29,16 +30,14 @@ test_that("get_train_template_id works", {
                                            name=c("training","prediction","training","registration","training","training"),
                                            stringsAsFactors=FALSE)
 
-  with_mock(
-    `civis::get_template_ids_all_versions` = function(...) fake_civis_ml_template_ids,
-
-    expect_equal(get_train_template_id("prod"), 11219),
-    expect_equal(get_train_template_id("dev"), 10615),
-    expect_equal(get_train_template_id("v2.2"), 11219),
-    expect_equal(get_train_template_id("v0.5"), 7020),
-    expect_error(get_train_template_id("foo"))
-
-    )
+  local_mocked_bindings(
+    get_template_ids_all_versions = function(...) fake_civis_ml_template_ids
+  )
+  expect_equal(get_train_template_id("prod"), 11219)
+  expect_equal(get_train_template_id("dev"), 10615)
+  expect_equal(get_train_template_id("v2.2"), 11219)
+  expect_equal(get_train_template_id("v0.5"), 7020)
+  expect_error(get_train_template_id("foo"))
 })
 
 
@@ -69,17 +68,16 @@ test_that("get_template_ids_all_versions works", {
                                            userId = 1750,
                                            displayName = "Trained Model Registration, v2.2"))
 
-  with_mock(
-     `civis::fetch_until` = function(...) fake_template_alias_objects,
-
-      expect_equal(get_template_ids_all_versions(),
-                   data.frame(id=c(11219,10615,11221),
-                              version=c("prod","dev","v2.2"),
-                              name=c("training","training","registration"),
-                              stringsAsFactors=FALSE)
-                   )
-      )
-
+  local_mocked_bindings(
+     fetch_until = function(...) fake_template_alias_objects
+  )
+  expect_equal(
+    get_template_ids_all_versions(),
+    data.frame(id = c(11219, 10615, 11221),
+      version = c("prod", "dev", "v2.2"),
+      name = c("training", "training", "registration"),
+      stringsAsFactors = FALSE)
+  )
 })
 
 
@@ -181,23 +179,16 @@ test_that("get_predict_template_id returns correct template for train/predict ve
 
   m <- model_list[[1]]
 
-  with_mock(
-    `civis::get_template_ids_all_versions` = function(...) fake_civis_ml_template_ids,
-
-    expect_equal(get_predict_template_id(m), 9969)
-
-    )
-
+  local_mocked_bindings(
+    get_template_ids_all_versions = function(...) fake_civis_ml_template_ids
+  )
+  expect_equal(get_predict_template_id(m), 9969)
 
   fake_model <- list(job = list(fromTemplateId = 10582))
-
-  with_mock(
-    `civis::get_template_ids_all_versions` = function(...) fake_civis_ml_template_ids,
-
-     expect_equal(get_predict_template_id(fake_model), 10583)
-
-    )
-
+  local_mocked_bindings(
+    get_template_ids_all_versions = function(...) fake_civis_ml_template_ids
+  )
+  expect_equal(get_predict_template_id(fake_model), 10583)
 })
 
 

--- a/tests/testthat/test_civis_ml_workflows.R
+++ b/tests/testthat/test_civis_ml_workflows.R
@@ -14,15 +14,15 @@ test_that("calls civis_ml with model_type", {
 test_that("calls civis_ml with params", {
   fake_civis_ml <- mock(NULL)
 
-  with_mock(
-    `civis::civis_ml` = fake_civis_ml,
-    civis_ml_sparse_logistic(iris,
-                             dependent_variable = "Species",
-                             C = 9,
-                             fit_intercept = FALSE,
-                             class_weight = "balanced",
-                             solver = "lbfgs")
+  local_mocked_bindings(
+    civis_ml = fake_civis_ml
   )
+  civis_ml_sparse_logistic(iris,
+                           dependent_variable = "Species",
+                           C = 9,
+                           fit_intercept = FALSE,
+                           class_weight = "balanced",
+                           solver = "lbfgs")
 
   ml_args <- mock_args(fake_civis_ml)[[1]]
   params <- ml_args$parameters
@@ -88,13 +88,13 @@ test_that("calls civis_ml with model_type", {
 test_that("calls civis_ml with params", {
   fake_civis_ml <- mock(NULL)
 
-  with_mock(
-    `civis::civis_ml` = fake_civis_ml,
-    civis_ml_sparse_linear_regressor(x = iris,
-                                     dependent_variable = "Sepal.Length",
-                                     fit_intercept = TRUE,
-                                     normalize = FALSE)
+  local_mocked_bindings(
+    civis_ml = fake_civis_ml
   )
+  civis_ml_sparse_linear_regressor(x = iris,
+                                    dependent_variable = "Sepal.Length",
+                                    fit_intercept = TRUE,
+                                    normalize = FALSE)
   ml_args <- mock_args(fake_civis_ml)[[1]]
   params <- ml_args$parameters
 
@@ -105,16 +105,16 @@ test_that("calls civis_ml with params", {
 test_that("warns when fit_intercept = FALSE and normalize = TRUE", {
   fake_civis_ml <- mock(NULL)
 
-  with_mock(
-    `civis::civis_ml` = fake_civis_ml,
-
-    expect_warning(
-      civis_ml_sparse_linear_regressor(x = iris,
-                                       dependent_variable = "Sepal.Length",
-                                       fit_intercept = FALSE,
-                                       normalize = TRUE),
-      "fit_intercept = FALSE, ignoring normalize\\.")
+  local_mocked_bindings(
+    civis_ml = fake_civis_ml
   )
+
+  expect_warning(
+    civis_ml_sparse_linear_regressor(x = iris,
+                                      dependent_variable = "Sepal.Length",
+                                      fit_intercept = FALSE,
+                                      normalize = TRUE),
+    "fit_intercept = FALSE, ignoring normalize\\.")
 })
 
 test_that("passes other args to civis_ml", {
@@ -135,18 +135,19 @@ test_that("passes other args to civis_ml", {
 test_that("calls civis_ml with params", {
   fake_civis_ml <- mock(NULL)
 
-  with_mock(
-    `civis::civis_ml` = fake_civis_ml,
-    civis_ml_sparse_ridge_regressor(x = iris,
-                                    dependent_variable = "Sepal.Length",
-                                    alpha = 10.5,
-                                    fit_intercept = FALSE,
-                                    normalize = TRUE,
-                                    max_iter = 9,
-                                    tol = 1e-8,
-                                    solver = "svd",
-                                    random_state = 561)
+  local_mocked_bindings(
+    civis_ml = fake_civis_ml
   )
+  civis_ml_sparse_ridge_regressor(x = iris,
+                                  dependent_variable = "Sepal.Length",
+                                  alpha = 10.5,
+                                  fit_intercept = FALSE,
+                                  normalize = TRUE,
+                                  max_iter = 9,
+                                  tol = 1e-8,
+                                  solver = "svd",
+                                  random_state = 561)
+
   ml_args <- mock_args(fake_civis_ml)[[1]]
   params <- ml_args$parameters
 
@@ -174,16 +175,17 @@ test_that("passes other args to civis_ml", {
 test_that("calls civis_ml with params", {
   fake_civis_ml <- mock(NULL)
 
-  with_mock(
-    `civis::civis_ml` = fake_civis_ml,
-    civis_ml_gradient_boosting_classifier(x = iris,
-                                          dependent_variable = "Species",
-                                          loss = "deviance",
-                                          learning_rate = 0.15,
-                                          n_estimators = 100,
-                                          subsample = 0.9,
-                                          criterion = "mse")
+  local_mocked_bindings(
+    civis_ml = fake_civis_ml
   )
+  civis_ml_gradient_boosting_classifier(x = iris,
+                                        dependent_variable = "Species",
+                                        loss = "deviance",
+                                        learning_rate = 0.15,
+                                        n_estimators = 100,
+                                        subsample = 0.9,
+                                        criterion = "mse")
+
   ml_args <- mock_args(fake_civis_ml)[[1]]
   params <- ml_args$parameters
 
@@ -217,19 +219,20 @@ test_that("passes other args to civis_ml", {
 test_that("calls civis_ml with params", {
   fake_civis_ml <- mock(NULL)
 
-  with_mock(
-    `civis::civis_ml` = fake_civis_ml,
-
-    civis_ml_sparse_ridge_regressor(x = iris,
-                                    dependent_variable = "Sepal.Length",
-                                    alpha = 10.5,
-                                    fit_intercept = FALSE,
-                                    normalize = TRUE,
-                                    max_iter = 9,
-                                    tol = 1e-8,
-                                    solver = "svd",
-                                    random_state = 561)
+  local_mocked_bindings(
+    civis_ml = fake_civis_ml
   )
+
+  civis_ml_sparse_ridge_regressor(x = iris,
+                                  dependent_variable = "Sepal.Length",
+                                  alpha = 10.5,
+                                  fit_intercept = FALSE,
+                                  normalize = TRUE,
+                                  max_iter = 9,
+                                  tol = 1e-8,
+                                  solver = "svd",
+                                  random_state = 561)
+
   ml_args <- mock_args(fake_civis_ml)[[1]]
   params <- ml_args$parameters
 
@@ -264,13 +267,14 @@ test_that("checks class_weight param", {
 test_that("calls civis_ml with params", {
   fake_civis_ml <- mock(NULL)
 
-  with_mock(
-    `civis::civis_ml` = fake_civis_ml,
-    civis_ml_random_forest_classifier(x = iris,
-                                      dependent_variable = "Species",
-                                      criterion = "entropy",
-                                      n_estimators = 100)
+  local_mocked_bindings(
+    civis_ml = fake_civis_ml
   )
+  civis_ml_random_forest_classifier(x = iris,
+                                    dependent_variable = "Species",
+                                    criterion = "entropy",
+                                    n_estimators = 100)
+
   ml_args <- mock_args(fake_civis_ml)[[1]]
   params <- ml_args$parameters
 
@@ -301,13 +305,13 @@ test_that("passes other args to civis_ml", {
 test_that("calls civis_ml with params", {
   fake_civis_ml <- mock(NULL)
 
-  with_mock(
-    `civis::civis_ml` = fake_civis_ml,
-    civis_ml_random_forest_regressor(x = iris,
-                                     dependent_variable = "Species",
-                                     criterion = "mae",
-                                     n_estimators = 100)
+  local_mocked_bindings(
+    civis_ml = fake_civis_ml
   )
+  civis_ml_random_forest_regressor(x = iris,
+                                    dependent_variable = "Species",
+                                    criterion = "mae",
+                                    n_estimators = 100)
   ml_args <- mock_args(fake_civis_ml)[[1]]
   params <- ml_args$parameters
 
@@ -345,13 +349,13 @@ test_that("checks class_weight param", {
 test_that("calls civis_ml with params", {
   fake_civis_ml <- mock(NULL)
 
-  with_mock(
-    `civis::civis_ml` = fake_civis_ml,
-    civis_ml_extra_trees_classifier(x = iris,
-                                    dependent_variable = "Species",
-                                    criterion = "entropy",
-                                    n_estimators = 100)
+  local_mocked_bindings(
+    civis_ml = fake_civis_ml
   )
+  civis_ml_extra_trees_classifier(x = iris,
+                                  dependent_variable = "Species",
+                                  criterion = "entropy",
+                                  n_estimators = 100)
   ml_args <- mock_args(fake_civis_ml)[[1]]
   params <- ml_args$parameters
 
@@ -382,13 +386,13 @@ test_that("passes other args to civis_ml", {
 test_that("calls civis_ml with params", {
   fake_civis_ml <- mock(NULL)
 
-  with_mock(
-    `civis::civis_ml` = fake_civis_ml,
-    civis_ml_extra_trees_regressor(x = iris,
-                                   dependent_variable = "Species",
-                                   criterion = "mae",
-                                   n_estimators = 100)
+  local_mocked_bindings(
+    civis_ml = fake_civis_ml
   )
+  civis_ml_extra_trees_regressor(x = iris,
+                                  dependent_variable = "Species",
+                                  criterion = "mae",
+                                  n_estimators = 100)
   ml_args <- mock_args(fake_civis_ml)[[1]]
   params <- ml_args$parameters
 

--- a/tests/testthat/test_io.R
+++ b/tests/testthat/test_io.R
@@ -15,29 +15,29 @@ test_that("read_civis.sql reads csvs", {
     write.csv(mock_df, file = filename, row.names = FALSE)
     return(filename)
   }
-  with_mock(
-    `civis::start_scripted_sql_job` = mock_sql_job,
-    `civis::scripts_post_sql_runs` = function(...) list(id = 1001),
-    `civis::scripts_get_sql_runs` = mock_get_sql_runs,
-    `civis::files_get` = function(...) list(fileSize = 4E9),
-    `civis::download_script_results` = mock_download_script_results,
-    `civis::stop_for_status` = function(...) return(TRUE),
-    expect_equal(mock_df, read_civis(x = "lazy", database = "jellyfish")),
-    expect_equal(mock_df, read_civis(sql("SELECT * FROM lazy"),
-                                     database = "jellyfish"))
+  local_mocked_bindings(
+    start_scripted_sql_job = mock_sql_job,
+    scripts_post_sql_runs = function(...) list(id = 1001),
+    scripts_get_sql_runs = mock_get_sql_runs,
+    files_get = function(...) list(fileSize = 4E9),
+    download_script_results = mock_download_script_results,
+    stop_for_status = function(...) return(TRUE)
   )
+  expect_equal(mock_df, read_civis(x = "lazy", database = "jellyfish"))
+  expect_equal(mock_df, read_civis(sql("SELECT * FROM lazy"),
+                                   database = "jellyfish"))
 })
 
 test_that("read_civis.sql produces catchable error when query returns no rows", {
   no_results_resp <- list(state = "succeeded", output = list())
 
   mock_sql_job <- function(...) list(script_id = 561, run_id = 43)
-  with_mock(
-    `civis::start_scripted_sql_job` = mock_sql_job,
-    `civis::scripts_get_sql_runs` = function(...) no_results_resp,
-    try_err <- try(read_civis(sql("SELECT 0"), database = "arrgh"), silent = TRUE),
-    expect_true("empty_result_error" %in% class(attr(try_err, "condition")))
+  local_mocked_bindings(
+    start_scripted_sql_job = mock_sql_job,
+    scripts_get_sql_runs = function(...) no_results_resp
   )
+  try_err <- try(read_civis(sql("SELECT 0"), database = "arrgh"), silent = TRUE)
+  expect_true("empty_result_error" %in% class(attr(try_err, "condition")))
 })
 
 test_that("read_civis.numeric reads a csv", {
@@ -46,12 +46,12 @@ test_that("read_civis.numeric reads a csv", {
     structure(list(url = "http://www.fakeurl.com", status_code = 200),
               class = "response")
   }
-  with_mock(
-    `civis::files_get` =  function(...) list(fileUrl = "fakeurl.com"),
-    `httr::RETRY` = mock_response,
-    `civis::download_civis` = function(id, fn) write.csv(d, file = fn),
-    expect_equal(d, read_civis(123, using = read.csv, row.names = 1))
+  local_mocked_bindings(
+    files_get =  function(...) list(fileUrl = "fakeurl.com"),
+    download_civis = function(id, fn) write.csv(d, file = fn),
+    httr_RETRY = mock_response,
   )
+  expect_equal(d, read_civis(123, using = read.csv, row.names = 1))
 })
 
 test_that("read_civis.numeric fails for NA", {
@@ -63,30 +63,30 @@ test_that("read_civis.civis_script using = NULL", {
   mock_output <- list(list(name = 'asdf', objectId = 1, objectType = 'JSONValue', value = 'a'),
                       list(name = 'fake', objectId = 2, objectType = 'JSONValue', value = 'b'),
                       list(name = 'file_fake', objectId = 3, objectType = 'File'))
-  vals <- with_mock(
-    `civis::jobs_get` = function(...) list(type = 'JobTypes::ContainerDocker'),
-    `civis::scripts_list_containers_runs_outputs` = function(...) mock_output,
-    expect_equal(read_civis(civis_script(1,1), using = NULL),
-                 list(asdf = 'a', fake = 'b')),
-    expect_equal(read_civis(civis_script(1,1), using = NULL, regex = 'fake'),
-                 list(fake = 'b'))
+  vals <- local_mocked_bindings(
+    jobs_get = function(...) list(type = 'JobTypes::ContainerDocker'),
+    scripts_list_containers_runs_outputs = function(...) mock_output
   )
+  expect_equal(read_civis(civis_script(1,1), using = NULL),
+               list(asdf = 'a', fake = 'b'))
+  expect_equal(read_civis(civis_script(1,1), using = NULL, regex = 'fake'),
+               list(fake = 'b'))
 })
 
 test_that("read_civis.civis_script with using", {
   mock_output <- list(list(name = 'asdf', objectId = 1, objectType = 'JSONValue', value = 'a'),
                       list(name = 'lol', objectId = 2, objectType = 'File'),
                       list(name = 'fake', objectId = 3, objectType = 'File'))
-  with_mock(
-    `civis::jobs_get` = function(...) list(type = 'JobTypes::ContainerDocker'),
-    `civis::scripts_list_containers_runs_outputs` = function(...) mock_output,
+  local_mocked_bindings(
+    jobs_get = function(...) list(type = 'JobTypes::ContainerDocker'),
+    scripts_list_containers_runs_outputs = function(...) mock_output,
     # returns first arg of read_civis.numeric, which is the objectId
-    `civis::read_civis.numeric` = function(...) list(...)[[1]],
-    expect_equal(read_civis(civis_script(1,1), using = I),
-                 list(lol = 2, fake = 3)),
-    expect_equal(read_civis(civis_script(1,1), regex = 'fake', using = I),
-                 list(fake = 3))
+    read_civis.numeric = function(...) list(...)[[1]]
   )
+  expect_equal(read_civis(civis_script(1, 1), using = I),
+                list(lol = 2, fake = 3))
+  expect_equal(read_civis(civis_script(1, 1), regex = 'fake', using = I),
+                list(fake = 3))
 })
 
 
@@ -95,143 +95,144 @@ test_that("read_civis.civis_script with using", {
 test_that("write_civis.character returns meta data if successful", {
   mock_df <- cbind.data.frame(a = c(1,2), b = c("cape-cod", "clams"))
   write("", file = "mockfile")
-  res <- with_mock(
-    `civis::start_import_job` = function(...) {
+  local_mocked_bindings(
+    start_import_job = function(...) {
       list(uploadUri = "fake", id = 1)
     },
-    `civis::default_credential` = function(...) 1234,
-    `civis::tables_post_refresh` = function(id) "",
-    `httr::RETRY` = function(...) list(status_code = 200),
-    `civis::imports_post_files_runs` = function(...) list(""),
-    `civis::imports_get_files_runs` = function(...) list(state = "succeeded"),
-      write_civis("mockfile", "mock.table", "mockdb")
-    )
+    default_credential = function(...) 1234,
+    tables_post_refresh = function(id) "",
+    imports_post_files_runs = function(...) list(""),
+    imports_get_files_runs = function(...) list(state = "succeeded"),
+    httr_RETRY = function(...) list(status_code = 200),
+  )
+  res <- write_civis("mockfile", "mock.table", "mockdb")
+
   unlink("mockfile")
   expect_equal(get_status(res), "succeeded")
 })
 
 test_that("write_civis.character fails if file doesn't exist", {
   mock_df <- cbind.data.frame(a = c(1,2), b = c("cape-cod", "clams"))
-  err_msg <- with_mock(
-    `civis::start_import_job` = function(...) {
+  local_mocked_bindings(
+    start_import_job = function(...) {
       list(uploadUri = "fake")
     },
-    `httr::RETRY` = function(...) list(status_code = 200),
-    `civis::imports_post_files_runs` = function(...) list(""),
-    `civis::imports_get_files_runs` = function(...) list(state = "succeeded"),
-    tryCatch(write_civis("mockfile", "mock.table", "mockdb"), error = function(e) e$message)
+    imports_post_files_runs = function(...) list(""),
+    imports_get_files_runs = function(...) list(state = "succeeded"),
+    httr_RETRY = function(...) list(status_code = 200),
   )
+  err_msg <- tryCatch(write_civis("mockfile", "mock.table", "mockdb"), error = function(e) e$message)
   msg <- "file.exists(x) is not TRUE"
   expect_equal(err_msg, msg)
 })
 
 test_that("write_civis.data.frame returns meta data if successful", {
   mock_df <- cbind.data.frame(a = c(1,2), b = c("cape-cod", "clams"))
-  res <- with_mock(
-    `civis::start_import_job` = function(...) {
+   local_mocked_bindings(
+    start_import_job = function(...) {
       list(uploadUri = "fake", id = 1)
     },
-    `civis::default_credential` = function(...) 1,
-    `civis::tables_post_refresh` = function(id) "",
-    `httr::RETRY` = function(...) list(status_code = 200),
-    `civis::imports_post_files_runs` = function(...) list(""),
-    `civis::imports_get_files_runs` = function(...) list(state = "succeeded"),
-    `civis::tables_list` = function(...) 1,
-    write_civis(mock_df, "mock.table", "mockdb")
+    default_credential = function(...) 1,
+    tables_post_refresh = function(id) "",
+    imports_post_files_runs = function(...) list(""),
+    imports_get_files_runs = function(...) list(state = "succeeded"),
+    tables_list = function(...) 1,
+    httr_RETRY = function(...) list(status_code = 200),
   )
+  res <- write_civis(mock_df, "mock.table", "mockdb")
+
   expect_equal(get_status(res), "succeeded")
 })
 
 test_that("write_civis.character warns under failure", {
   mock_df <- cbind.data.frame(a = c(1,2), b = c("cape-cod", "clams"))
-  with_mock(
-    `civis::start_import_job` = function(...) {
+  local_mocked_bindings(
+    start_import_job = function(...) {
       list(uploadUri = "fake", id = -999)
     },
-    `httr::RETRY` = function(...) list(status_code = 200),
-    `civis::imports_post_files_runs` = function(...) "",
-    `civis::imports_get_files_runs` = function(...) list(state = "failed"),
-    `httr::content` = function(...) "error",
-    expect_error(
-      write_civis("mockfile", "mock.table", "mockdb"))
+    imports_post_files_runs = function(...) "",
+    imports_get_files_runs = function(...) list(state = "failed"),
+    httr_RETRY = function(...) list(status_code = 200),
+    httr_content = function(...) "error",
   )
+  expect_error(write_civis("mockfile", "mock.table", "mockdb"))
 })
 
 test_that("write_civis.character calls imports endpoints correctly", {
   ipf <- mock(list(id = 4))
   fn <- tempfile(fileext = ".csv")
   file.create(fn)
-  with_mock(
-    `civis:::get_database_id` = function(...) 32,
-    `civis:::default_credential` = function(...) 999,
-    `civis::imports_post_files` = ipf,
-    `civis::imports_post_files_runs` = function(...) list(id = 44),
-    `civis::imports_get_files_runs` = function(...) list(state = "succeeded"),
-    `httr::RETRY` = mock(list(status_code = 200)),
-    res <- write_civis(fn, "mock.table", "mockdb", credential_id = 1),
-    expect_equal(get_status(res), "succeeded"),
-    expect_args(ipf, n = 1,
-                schema = 'mock',
-                name = 'table',
-                remote_host_id = 32,
-                credential_id = 1,
-                max_errors = NULL,
-                existing_table_rows = "fail",
-                diststyle = NULL,
-                distkey = NULL,
-                sortkey1 = NULL,
-                sortkey2 = NULL,
-                column_delimiter = "comma",
-                firstRowIsHeader = TRUE,
-                hidden = TRUE
-    )
+  local_mocked_bindings(
+    get_database_id = function(...) 32,
+    default_credential = function(...) 999,
+    imports_post_files = ipf,
+    imports_post_files_runs = function(...) list(id = 44),
+    imports_get_files_runs = function(...) list(state = "succeeded"),
+    httr_RETRY = mock(list(status_code = 200)),
+  )
+  res <- write_civis(fn, "mock.table", "mockdb", credential_id = 1)
+  expect_equal(get_status(res), "succeeded")
+  expect_args(ipf, n = 1,
+              schema = 'mock',
+              name = 'table',
+              remote_host_id = 32,
+              credential_id = 1,
+              max_errors = NULL,
+              existing_table_rows = "fail",
+              diststyle = NULL,
+              distkey = NULL,
+              sortkey1 = NULL,
+              sortkey2 = NULL,
+              column_delimiter = "comma",
+              firstRowIsHeader = TRUE,
+              hidden = TRUE
   )
 })
 
 test_that("write_civis.numeric calls imports endpoints correctly", {
   ip <- mock(list(id = 4))
-  with_mock(
-    `civis:::get_database_id` = function(...) 32,
-    `civis:::default_credential` = function(...) 999,
-    `civis::imports_post` =  ip,
-    `civis::imports_post_syncs` = mock(),
-    `civis::jobs_post_runs` = function(...) list(id = 4),
-    `civis::jobs_get_runs` = function(...) list(state = "succeeded"),
-    res <- write_civis(1234, "mock.table", "mockdb", credential_id = 1,
-                      import_args = list(verifyTableRowCounts = TRUE)),
-    expect_equal(get_status(res), "succeeded"),
-    expect_args(ip, n = 1,
-                 import_name = "CSV import to mock.table",
-                 sync_type = 'AutoImport',
-                 is_output = FALSE,
-                 destination = list(remote_host_id = 32, credential_id = 1),
-                 hidden = TRUE),
-    expect_args(civis::imports_post_syncs, n = 1,
-                id = 4,
-                list(file = list(id = 1234)),
-                destination = list(database_table =
-                                     list(schema = "mock", table = "table")),
-                advanced_options = list(
-                  max_errors = NULL,
-                  existing_table_rows = "fail",
-                  distkey = NULL,
-                  diststyle = NULL,
-                  sortkey1 = NULL,
-                  sortkey2 = NULL,
-                  column_delimiter = "comma",
-                  firstRowIsHeader = TRUE,
-                  verifyTableRowCounts = TRUE
-                ))
+  local_mocked_bindings(
+    get_database_id = function(...) 32,
+    default_credential = function(...) 999,
+    imports_post =  ip,
+    imports_post_syncs = mock(),
+    jobs_post_runs = function(...) list(id = 4),
+    jobs_get_runs = function(...) list(state = "succeeded")
   )
+  res <- write_civis(1234, "mock.table", "mockdb", credential_id = 1,
+                     import_args = list(verifyTableRowCounts = TRUE))
+  expect_equal(get_status(res), "succeeded")
+  expect_args(ip, n = 1,
+                import_name = "CSV import to mock.table",
+                sync_type = 'AutoImport',
+                is_output = FALSE,
+                destination = list(remote_host_id = 32, credential_id = 1),
+                hidden = TRUE)
+  expect_args(civis::imports_post_syncs, n = 1,
+              id = 4,
+              list(file = list(id = 1234)),
+              destination = list(database_table =
+                                    list(schema = "mock", table = "table")),
+              advanced_options = list(
+                max_errors = NULL,
+                existing_table_rows = "fail",
+                distkey = NULL,
+                diststyle = NULL,
+                sortkey1 = NULL,
+                sortkey2 = NULL,
+                column_delimiter = "comma",
+                firstRowIsHeader = TRUE,
+                verifyTableRowCounts = TRUE
+              ))
 })
 
 test_that("write_civis fails if no db given and default not provided", {
-  with_mock(
-    `civis::get_default_database` = function(...) NULL,
-    err_msg <- tryCatch(write_civis(iris), error = function(e) e$message),
-    db_err <- tryCatch(get_db(NULL), error = function(e) e$message),
-    expect_equal(err_msg, db_err)
+  local_mocked_bindings(
+    get_default_database = function(...) NULL
   )
+  err_msg <- tryCatch(write_civis(iris), error = function(e) e$message)
+  db_err <- tryCatch(get_db(NULL), error = function(e) e$message)
+  expect_equal(err_msg, db_err)
 })
 
 test_that("write_civis.numeric fails for NA", {
@@ -251,25 +252,25 @@ test_that("write_civis_file fails if character vector length 2 is passed", {
 
 test_that("write_civis_file.character returns a file id", {
   write("", "mockfile.txt")
-  with_mock(
-    `civis::files_post` = function(...) list(uploadFields = list("fakeurl.com"), id = 5),
-    `httr::upload_file` = function(...) "the file",
-    `httr::RETRY` = function(...) structure(list(status_code = 200), class = "response"),
-     expect_equal(write_civis_file("mockfile.txt", name = "mockfile.txt"), 5)
+  local_mocked_bindings(
+    files_post = function(...) list(uploadFields = list("fakeurl.com"), id = 5),
+    httr_upload_file = function(...) "the file",
+    httr_RETRY = function(...) structure(list(status_code = 200), class = "response"),
   )
+  expect_equal(write_civis_file("mockfile.txt", name = "mockfile.txt"), 5)
   unlink("mockfile.txt")
 })
 
 test_that("write_civis_file returns a file id", {
   mock_df <- data.frame(a = c(1,2), b = c("cape-cod", "clams"))
-  with_mock(
-    `civis::files_post` = function(...) list(uploadFields = list("fakeurl.com"), id = 5),
-    `httr::upload_file` = function(...) "the file",
-    `httr::RETRY` = function(...) structure(list(status_code = 200), class = "response"),
-    expect_equal(write_civis_file(mock_df), 5),
-    expect_equal(write_civis_file(as.list(mock_df)), 5),
-    expect_equal(write_civis_file(1:3), 5)
+  local_mocked_bindings(
+    files_post = function(...) list(uploadFields = list("fakeurl.com"), id = 5),
+    httr_upload_file = function(...) "the file",
+    httr_RETRY = function(...) structure(list(status_code = 200), class = "response"),
   )
+  expect_equal(write_civis_file(mock_df), 5)
+  expect_equal(write_civis_file(as.list(mock_df)), 5)
+  expect_equal(write_civis_file(1:3), 5)
 })
 
 test_that("write_civis_file calls multipart_unload for big files", {
@@ -277,24 +278,24 @@ test_that("write_civis_file calls multipart_unload for big files", {
   mockery::stub(write_civis_file.character, "file.size", MIN_MULTIPART_SIZE + 1)
   fn <- tempfile()
   file.create(fn)
-  with_mock(
-    `civis::multipart_upload` = function(...) 1,
-    expect_equal(write_civis_file(fn, name = "asdf"), 1)
+  local_mocked_bindings(
+    multipart_upload = function(...) 1
   )
+  expect_equal(write_civis_file(fn, name = "asdf"), 1)
   unlink(fn)
 })
 
 test_that("write_civis_file.data.frame uploads a csv", {
   m <- mock()
-  with_mock(
-    `civis::with_tempfile` = m,
-    `civis:::write_civis_file.character` = function(...) 1,
-    write_civis_file(iris),
-    # call the temporary function given to with_tempfile
-    mock_args(m)[[1]][[1]]('tmp.csv'),
-    expect_equal(read.csv('tmp.csv', stringsAsFactors = TRUE), iris),
-    unlink('tmp.csv')
+  local_mocked_bindings(
+    with_tempfile = m,
+    write_civis_file.character = function(...) 1
   )
+  write_civis_file(iris)
+  # call the temporary function given to with_tempfile
+  mock_args(m)[[1]][[1]]('tmp.csv')
+  expect_equal(read.csv('tmp.csv', stringsAsFactors = TRUE), iris)
+  unlink('tmp.csv')
 })
 
 # download_civis --------------------------------------------------------------
@@ -322,14 +323,14 @@ test_that("download_civis.numeric fails for NA", {
 
 test_that("query_civis returns object from await", {
   qp <- mockery::mock()
-  with_mock(
-    `civis::get_database_id` = function(...) TRUE,
-    `civis::default_credential` = function(...) 1,
-    `civis::queries_post` = qp,
-    `civis::queries_get` = function(...) list(state = 'succeeded'),
-    expect_equal(get_status(query_civis("query", "database", credential = 10)), 'succeeded'),
-    expect_equal(mockery::mock_args(qp)[[1]]$credential, 10)
+  local_mocked_bindings(
+    get_database_id = function(...) TRUE,
+    default_credential = function(...) 1,
+    queries_post = qp,
+    queries_get = function(...) list(state = 'succeeded')
   )
+  expect_equal(get_status(query_civis("query", "database", credential = 10)), 'succeeded')
+  expect_equal(mockery::mock_args(qp)[[1]]$credential, 10)
 })
 
 test_that("query_civis.numeric fails for NA", {
@@ -339,16 +340,16 @@ test_that("query_civis.numeric fails for NA", {
 
 test_that("query_civis_file.sql works", {
   qp <- mockery::mock()
-  with_mock(
-    `civis::get_database_id` = function(...) TRUE,
-    `civis::get_db` = function(...) "asdf",
-    `civis::default_credential` = function(...) 1,
-    `civis:::start_scripted_sql_job` = qp,
-    `civis::scripts_get_sql_runs` = function(...) list(state = "succeeded",
-                                                       output = list(list(fileId = 1))),
-    expect_equal(query_civis_file(sql("asdf"), credential = 10), 1),
-    expect_equal(mockery::mock_args(qp)[[1]]$credential, 10)
+  local_mocked_bindings(
+    get_database_id = function(...) TRUE,
+    get_db = function(...) "asdf",
+    default_credential = function(...) 1,
+    start_scripted_sql_job = qp,
+    scripts_get_sql_runs = function(...) list(state = "succeeded",
+                                              output = list(list(fileId = 1)))
   )
+  expect_equal(query_civis_file(sql("asdf"), credential = 10), 1)
+  expect_equal(mockery::mock_args(qp)[[1]]$credential, 10)
 })
 
 test_that("query_civis_file.character errors if not schema.tablename", {
@@ -357,12 +358,12 @@ test_that("query_civis_file.character errors if not schema.tablename", {
 })
 
 test_that("query_civis_file.numeric works", {
-  with_mock(
-    `civis::scripts_post_sql_runs` = function(...) list(id = 333),
-    `civis::scripts_get_sql_runs` = function(...) list(state = "succeeded",
-                                                       output = list(list(fileId = 1))),
-    expect_equal(query_civis_file(234), 1)
+  local_mocked_bindings(
+    scripts_post_sql_runs = function(...) list(id = 333),
+    scripts_get_sql_runs = function(...) list(state = "succeeded",
+                                              output = list(list(fileId = 1)))
   )
+  expect_equal(query_civis_file(234), 1)
 })
 
 test_that("query_civis_file.numeric fails for NA", {
@@ -371,15 +372,15 @@ test_that("query_civis_file.numeric fails for NA", {
 })
 
 test_that("transfer_table succeeds", {
-  res <- with_mock(
-    `civis::default_credential` = function(...) 1,
-    `civis::get_database_id` = function(...) 32,
-    `civis::imports_post` = function(...) list(id = 999),
-    `civis::imports_post_syncs` = function(...) NULL,
-    `civis::imports_post_runs` = function(...) list(runId = 999),
-    `civis::imports_get_files_runs` = function(...) list(state = "succeeded"),
-    transfer_table("db1", "db2", "sc.tb1", "sc.tb2")
+  local_mocked_bindings(
+    default_credential = function(...) 1,
+    get_database_id = function(...) 32,
+    imports_post = function(...) list(id = 999),
+    imports_post_syncs = function(...) NULL,
+    imports_post_runs = function(...) list(runId = 999),
+    imports_get_files_runs = function(...) list(state = "succeeded")
   )
+  res <- transfer_table("db1", "db2", "sc.tb1", "sc.tb2")
   expect_equal(get_status(res), "succeeded")
 })
 
@@ -389,13 +390,13 @@ test_that("multipart_upload returns file_id", {
   fn <- tempfile()
   d <- data.frame(a = 1:5, b = 5:1)
   write.csv(d, fn, row.names = FALSE)
-  id <- with_mock(
-    `civis::upload_one` = function(...) NULL,
-    `civis::files_post_multipart` = function(...) list(id = 1, uploadUrls = "url"),
-    `future::value` = function(...) NULL,
-    `civis::files_post_multipart_complete` = function(...) NULL,
-    multipart_upload(fn, name = "asdf")
+  local_mocked_bindings(
+    upload_one = function(...) NULL,
+    files_post_multipart = function(...) list(id = 1, uploadUrls = "url"),
+    files_post_multipart_complete = function(...) NULL,
+    future_value = function(...) NULL,
   )
+  id <- multipart_upload(fn, name = "asdf")
   expect_equal(id, 1)
 })
 
@@ -430,15 +431,15 @@ test_that("write_chunks splits files", {
 test_that("get_db returns default database or an error", {
   expect_equal(get_db("sea_creatures"), "sea_creatures")
 
-  msg <- c("Argument database is NULL and options(\"civis.default_db\") not set. Set this option using options(civis.default_db = \"my_database\")")
-  test_msg <- with_mock(
-    `civis::get_default_database` = function(...) NULL,
-    tryCatch(get_db(NULL), error = function(e) e$message)
-  )
-  expect_equal(msg, test_msg)
-
   options(civis.default_db = "sea_creatures")
   expect_equal(get_db(NULL), "sea_creatures")
+
+  expected_msg <- c("Argument database is NULL and options(\"civis.default_db\") not set. Set this option using options(civis.default_db = \"my_database\")")
+  local_mocked_bindings(
+    get_default_database = function(...) NULL
+  )
+  actual_msg <- tryCatch(get_db(NULL), error = function(e) e$message)
+  expect_equal(expected_msg, actual_msg)
 })
 
 test_that("delimiter_name_from_string catches bad input", {
@@ -454,43 +455,43 @@ test_that("delimiter_name_from_string catches bad input", {
 
 
 test_that("start_import_job parses table correctly", {
-  with_mock(
-    `civis::get_database_id` = function(...) -999,
-    `civis::default_credential` = function(...) "fake",
-    `civis::imports_post_files` = function(...) {
+  local_mocked_bindings(
+    get_database_id = function(...) -999,
+    default_credential = function(...) "fake",
+    imports_post_files = function(...) {
       args <- list(...)
       list(schema = args[[1]], table = args[[2]])
-    },
-    expect_equal(
-      start_import_job("mockdb", "mock.table", if_exists = "append",
-                       NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
-      list(schema = "mock", table = "table")
-    )
+    }
+  )
+  expect_equal(
+    start_import_job("mockdb", "mock.table", if_exists = "append",
+                      NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+    list(schema = "mock", table = "table")
   )
 })
 
 test_that("start_import_job checks if_exists value", {
   error_msg <- 'if_exists must be set to "fail", "truncate", "append", or "drop"'
-  with_mock(
-    `civis::get_database_id` = function(...) -999,
-    `civis::default_credential` = function(...) "fake",
-    `civis::imports_post_files` = function(...) {
+  local_mocked_bindings(
+    get_database_id = function(...) -999,
+    default_credential = function(...) "fake",
+    imports_post_files = function(...) {
       args <- list(...)
       list(schema = args[[1]], table = args[[2]])
-    },
-    expect_error(
-      start_import_job("mockdb", "mock.table", if_exists = "do nothing",
-                       NULL, NULL, NULL, NULL),
-      error_msg
-    )
+    }
+  )
+  expect_error(
+    start_import_job("mockdb", "mock.table", if_exists = "do nothing",
+                      NULL, NULL, NULL, NULL),
+    error_msg
   )
 })
 
 test_that("download_script_results returns sensible errors", {
   error <- "Query produced no output. \\(script_id = 561, run_id = 43\\)"
   mock_get_run <- function(script_id, run_id) list(script_id = script_id, run_id = run_id)
-  with_mock(
-    `civis::scripts_get_sql_runs` = mock_get_run,
-    expect_error(download_script_results(561, 43, "some_file"), error)
+  local_mocked_bindings(
+    scripts_get_sql_runs = mock_get_run
   )
+  expect_error(download_script_results(561, 43, "some_file"), error)
 })

--- a/tests/testthat/test_logs.R
+++ b/tests/testthat/test_logs.R
@@ -34,13 +34,10 @@ fake_model <- structure(
 
 test_that("fetch_logs.civis_ml calls scripts_list_custom_runs_logs", {
   fake_scripts_list_custom_runs_logs <- mock(log_response)
-
-  with_mock(
-    `civis::scripts_list_custom_runs_logs` = fake_scripts_list_custom_runs_logs,
-
-    fetch_logs(fake_model)
+  local_mocked_bindings(
+    scripts_list_custom_runs_logs = fake_scripts_list_custom_runs_logs
   )
-
+  fetch_logs(fake_model)
   expect_args(fake_scripts_list_custom_runs_logs, 1,
               id = fake_model$job$id,
               run_id = fake_model$run$id,
@@ -68,10 +65,10 @@ test_that("fetch_logs.civis_api calls the right logging function with right args
   fake_scripts_list_sql_runs_logs <- mock(log_response)
   log_args <- attr(fake_api, "args")
 
-  with_mock(
-    `civis::scripts_list_sql_runs_logs` = fake_scripts_list_sql_runs_logs,
-    expect_equal(fetch_logs(fake_api), format_scripts_logs(log_response))
+  local_mocked_bindings(
+    scripts_list_sql_runs_logs = fake_scripts_list_sql_runs_logs
   )
+  expect_equal(fetch_logs(fake_api), format_scripts_logs(log_response))
   expect_args(fake_scripts_list_sql_runs_logs, 1,
               id = log_args$id, run_id = log_args$run_id, limit = 100)
 })
@@ -88,23 +85,18 @@ test_that("fetch_logs.civis_error calls the right logging function with right ar
   fake_scripts_list_sql_runs_logs <- mock(log_response)
   log_args <- attr(fake_api_err, "args")
 
-  with_mock(
-    `civis::scripts_list_sql_runs_logs` = fake_scripts_list_sql_runs_logs,
-    expect_equal(fetch_logs(fake_api_err), format_scripts_logs(log_response))
+  local_mocked_bindings(
+    scripts_list_sql_runs_logs = fake_scripts_list_sql_runs_logs
   )
+  expect_equal(fetch_logs(fake_api_err), format_scripts_logs(log_response))
   expect_args(fake_scripts_list_sql_runs_logs, 1,
               id = log_args$id, run_id = log_args$run_id, limit = 100)
 })
 
 test_that("formats the log messages", {
   # note: do *NOT* test time formatting in messages.
-  fake_scripts_list_custom_runs_logs <- mock(log_response)
-
-  msgs <- with_mock(
-    `civis::scripts_list_custom_runs_logs` = fake_scripts_list_custom_runs_logs,
-
-    fetch_logs(fake_model)
-  )
+  local_mocked_bindings(scripts_list_custom_runs_logs = mock(log_response))
+  msgs <- fetch_logs(fake_model)
   msg_lines <- strsplit(msgs, "\n")
   expected_messages <- c("Process used approximately 83.28 MiB of its 3188 limit", "Script complete.")
   for (i in 1:2) expect_true(grepl(expected_messages[i], msg_lines[i]))

--- a/tests/testthat/test_reports.R
+++ b/tests/testthat/test_reports.R
@@ -4,65 +4,65 @@ context("reports")
 
 test_that("rmd_file overwritting warning is called", {
   warn_msg <- "parameter 'input' is ignored. Using 'rmd_file' instead."
-  with_mock(
-    `rmarkdown::render` = function(...) TRUE,
-    `civis::publish_html` = function(...) -999,
-    `civis::parse_front_matter` = function(...) list(),
-    expect_warning(publish_rmd("fake.Rmd", input = "duplicate"), warn_msg)
+  local_mocked_bindings(
+    publish_html = function(...) -999,
+    parse_front_matter = function(...) list(),
+    rmarkdown_render = function(...) TRUE,
   )
+  expect_warning(publish_rmd("fake.Rmd", input = "duplicate"), warn_msg)
 })
 
 test_that("output_file overrides temp file when passed.", {
   output_file <- "keep_me.html"
   mock_publish_html <- mockery::mock(NULL)
-  with_mock(
-    `civis::publish_html` = mock_publish_html,
-    `rmarkdown::render` = function(...) TRUE,
-    `civis::parse_front_matter` = function(...) list(),
-    publish_rmd("fake.Rmd", output_file = output_file)
+  local_mocked_bindings(
+    publish_html = mock_publish_html,
+    parse_front_matter = function(...) list(),
+    rmarkdown_render = function(...) TRUE,
   )
+  publish_rmd("fake.Rmd", output_file = output_file)
   publish_html_args <- mockery::mock_args(mock_publish_html)[[1]]
   expect_equal(publish_html_args[[1]], output_file)
 })
 
 test_that("publish_html calls reports_put_project", {
   mock_reports_put_projects <- mockery::mock(reports_put_projects)
-  with_mock(
-    `readChar` = function(...) TRUE,
-    `civis::reports_post` = function(...) list(id = "fake_report"),
-    `civis::reports_put_projects` = mock_reports_put_projects,
-    publish_html("fake.html", project_id = "project_1")
+  local_mocked_bindings(
+    readChar = function(...) TRUE,
+    reports_post = function(...) list(id = "fake_report"),
+    reports_put_projects = mock_reports_put_projects,
   )
+  publish_html("fake.html", project_id = "project_1")
   expect_args(mock_reports_put_projects, 1, id = "fake_report", project_id = "project_1")
 })
 
 test_that("publish_html does not call reports_put_projects", {
-  with_mock(
-    `readChar` = function(...) TRUE,
-    `civis::reports_post` = function(...) list(id = "fake_report"),
-    `civis::reports_put_projects` = function(id, project_id) stop("should not be called"),
-    expect_silent(publish_html("fake.html"))
+  local_mocked_bindings(
+    readChar = function(...) TRUE,
+    reports_post = function(...) list(id = "fake_report"),
+    reports_put_projects = function(id, project_id) stop("should not be called"),
   )
+  expect_silent(publish_html("fake.html"))
 })
 
 test_that("publish_html can put an existing report", {
-  with_mock(
-    `readChar` = function(...) TRUE,
-    `civis::reports_patch` = function(report_id, ...) list(id = report_id),
-    `civis::reports_post` = function(...) stop("should not be called"),
-    expect_equal(publish_html("fake_html", report_id = 123), 123)
+  local_mocked_bindings(
+    readChar = function(...) TRUE,
+    reports_patch = function(report_id, ...) list(id = report_id),
+    reports_post = function(...) stop("should not be called"),
   )
+  expect_equal(publish_html("fake_html", report_id = 123), 123)
 })
 
 test_that("publish_rmd passes project_id", {
   mock_publish_html <- mockery::mock(NULL, cycle=TRUE)
-  with_mock(
-    `civis::publish_html` = mock_publish_html,
-    `rmarkdown::render` = function(...) TRUE,
-    `civis::parse_front_matter` = function(...) list(),
-    publish_rmd("rmd", project_id = "abc123"),
-    publish_rmd("rmd")
+  local_mocked_bindings(
+    publish_html = mock_publish_html,
+    rmarkdown_render = function(...) TRUE,
+    parse_front_matter = function(...) list(),
   )
+  publish_rmd("rmd", project_id = "abc123")
+  publish_rmd("rmd")
   publish_html_args <- mockery::mock_args(mock_publish_html)
   expect_equal("abc123", publish_html_args[[1]][["project_id"]])
   expect_null(publish_html_args[[2]][["project_id"]])
@@ -70,13 +70,13 @@ test_that("publish_rmd passes project_id", {
 
 test_that("publish_rmd passes report_id", {
   mock_publish_html <- mockery::mock(NULL, cycle=TRUE)
-  with_mock(
-    `civis::publish_html` = mock_publish_html,
-    `rmarkdown::render` = function(...) TRUE,
-    `civis::parse_front_matter` = function(...) list(),
-    publish_rmd("rmd", report_id = 123),
-    publish_rmd("rmd")
+  local_mocked_bindings(
+    publish_html = mock_publish_html,
+    rmarkdown_render = function(...) TRUE,
+    parse_front_matter = function(...) list(),
   )
+  publish_rmd("rmd", report_id = 123)
+  publish_rmd("rmd")
   publish_html_args <- mockery::mock_args(mock_publish_html)
   expect_equal(123, publish_html_args[[1]][["report_id"]])
   expect_null(publish_html_args[[2]][["report_id"]])

--- a/tests/testthat/test_rstudio.R
+++ b/tests/testthat/test_rstudio.R
@@ -2,27 +2,32 @@ library(civis)
 context("rstudio")
 
 test_that("publish_addin errors nicely when no path is present", {
-  mock_context <- list(path="", id="")  # path is empty here
+  mock_context <- list(path = "", id = "")  # path is empty here
   mockery::stub(publish_addin, "utils::browseURL", NULL)
-  with_mock(
-    `rstudioapi::getSourceEditorContext` = function(...) mock_context,
-    `rstudioapi::hasFun` = function(...) FALSE,
-    `rstudioapi::documentSave` = function(...) FALSE,
-    `civis::publish_rmd` = function(...) 123,
-    expect_error(publish_addin(), "Please save file before publishing.")
+  local_mocked_bindings(
+    getSourceEditorContext = function(...) mock_context,
+    hasFun = function(...) FALSE,
+    documentSave = function(...) FALSE,
+    # It seems reasonable to mock the functions in the rstudioapi package here
+    # since they shouldn't be called by other packages.
+    # See https://testthat.r-lib.org/reference/local_mocked_bindings.html#namespaced-calls
+    .package = "rstudioapi"
   )
+  local_mocked_bindings(publish_rmd = function(...) 123)
+  expect_error(publish_addin(), "Please save file before publishing.")
 })
 
 test_that("publish_addin errors nicely when path is not RMarkdown", {
   mock_context <- list(path="not_rmd.txt", id="")  # path is not .rmd here
   mockery::stub(publish_addin, "utils::browseURL", NULL)
-  with_mock(
-    `rstudioapi::getSourceEditorContext` = function(...) mock_context,
-    `rstudioapi::hasFun` = function(...) FALSE,
-    `rstudioapi::documentSave` = function(...) FALSE,
-    `civis::publish_rmd` = function(...) 123,
-    expect_error(publish_addin(), "Only RMarkdown files.*")
+  local_mocked_bindings(
+    getSourceEditorContext = function(...) mock_context,
+    hasFun = function(...) FALSE,
+    documentSave = function(...) FALSE,
+    .package = "rstudioapi"
   )
+  local_mocked_bindings(publish_rmd = function(...) 123)
+  expect_error(publish_addin(), "Only RMarkdown files.*")
 })
 
 test_that("publish_addin opens the correct url", {
@@ -31,12 +36,13 @@ test_that("publish_addin opens the correct url", {
   mock_context <- list(path="fake.Rmd", id="")
   mockery::stub(publish_addin, "utils::browseURL", mock_browseurl)
   url <- "https://platform.civisanalytics.com/#/reports/123?fullscreen=true"
-  with_mock(
-    `rstudioapi::getSourceEditorContext` = function(...) mock_context,
-    `rstudioapi::hasFun` = function(...) FALSE,
-    `rstudioapi::documentSave` = function(...) FALSE,
-    `civis::publish_rmd` = function(...) 123,
-    publish_addin()
+  local_mocked_bindings(
+    getSourceEditorContext = function(...) mock_context,
+    hasFun = function(...) FALSE,
+    documentSave = function(...) FALSE,
+    .package = "rstudioapi"
   )
+  local_mocked_bindings(publish_rmd = function(...) 123)
+  publish_addin()
   expect_args(mock_browseurl, 1, url)
 })

--- a/tests/testthat/test_scripts.R
+++ b/tests/testthat/test_scripts.R
@@ -3,26 +3,26 @@ context("scripts")
 test_that('fetch_output_file_ids returns named list of file_ids', {
   mock_output <- list(list(name = 'fake_name', objectId = 1),
                       list(name = 'asdf', objectId = 2))
-  with_mock(
-    `civis::jobs_get` = function(...)  list(type = 'JobTypes::ContainerDocker'),
-    `civis::scripts_list_containers_runs_outputs` = function(...) mock_output,
-    expect_equal(fetch_output_file_ids(civis_script(1,1), NULL),
-                 list(fake_name = 1, asdf = 2)),
-    expect_equal(fetch_output_file_ids(civis_script(1,1), 'fake'),
-                 list(fake_name = 1))
+  local_mocked_bindings(
+    jobs_get = function(...)  list(type = 'JobTypes::ContainerDocker'),
+    scripts_list_containers_runs_outputs = function(...) mock_output,
   )
+  expect_equal(fetch_output_file_ids(civis_script(1,1), NULL),
+               list(fake_name = 1, asdf = 2))
+  expect_equal(fetch_output_file_ids(civis_script(1,1), 'fake'),
+               list(fake_name = 1))
 })
 
 test_that("fetch_output dispatches correct function", {
   mock_output <- list(list(name = 'fake_name'), list(name = 'asdf'))
-  with_mock(
-    `civis::jobs_get` = function(...)  list(type = 'JobTypes::ContainerDocker'),
-    `civis::scripts_list_containers_runs_outputs` = function(...) mock_output,
-    expect_equal(fetch_output(civis_script(1,1)),
-                 mock_output),
-    expect_equal(fetch_output(civis_script(1,1), regex = 'fake'),
-                 mock_output[1])
+  local_mocked_bindings(
+    jobs_get = function(...)  list(type = 'JobTypes::ContainerDocker'),
+    scripts_list_containers_runs_outputs = function(...) mock_output,
   )
+  expect_equal(fetch_output(civis_script(1,1)),
+               mock_output)
+  expect_equal(fetch_output(civis_script(1,1), regex = 'fake'),
+               mock_output[1])
 })
 
 test_that("test civis_script", {
@@ -37,13 +37,13 @@ test_that("write_job_output posts", {
   Sys.setenv('CIVIS_RUN_ID' = 2)
   mock_post <- mockery::mock(1)
   mock_job <- list(type = 'JobTypes::ContainerDocker', fromTemplateId = 1)
-  val <- with_mock(
-    `civis::jobs_get` = function(...) mock_job,
-    `write_civis_file` = function(...) 3,
-    `civis::scripts_post_custom_runs_outputs` = mock_post,
-    write_job_output('asdf'),
-    mockery::expect_called(mock_post, 1)
+  local_mocked_bindings(
+    jobs_get = function(...) mock_job,
+    write_civis_file = function(...) 3,
+    scripts_post_custom_runs_outputs = mock_post,
   )
+  write_job_output('asdf')
+  mockery::expect_called(mock_post, 1)
   Sys.unsetenv("CIVIS_JOB_ID" )
   Sys.unsetenv("CIVIS_RUN_ID")
   expect_null(write_job_output('asdf'))
@@ -52,14 +52,14 @@ test_that("write_job_output posts", {
 test_that("run_template", {
   mock_output <- list(list(name = 'a', objectId = 1))
   mock_post <- mockery::mock(list(id = 1))
-  vals <- with_mock(
-    `civis::scripts_post_custom` =  mock_post,
-    `civis::scripts_post_custom_runs` = function(...) list(id = 1),
-    `civis::scripts_get_custom_runs` = function(...) list(state = 'succeeded'),
-    `civis::jobs_get` = function(...) list(type = 'JobTypes::ContainerDocker', fromTemplateId = 1),
-    `civis::scripts_list_custom_runs_outputs` = function(...) mock_output,
-    run_template(1, arguments = list(arg = 1), credential_id = 1)
+  local_mocked_bindings(
+    scripts_post_custom =  mock_post,
+    scripts_post_custom_runs = function(...) list(id = 1),
+    scripts_get_custom_runs = function(...) list(state = 'succeeded'),
+    jobs_get = function(...) list(type = 'JobTypes::ContainerDocker', fromTemplateId = 1),
+    scripts_list_custom_runs_outputs = function(...) mock_output,
   )
+  vals <- run_template(1, arguments = list(arg = 1), credential_id = 1)
   expect_equal(vals, list(a = 1))
   mockery::expect_called(mock_post, 1)
   expect_equal(mockery::mock_args(mock_post)[[1]],
@@ -69,14 +69,14 @@ test_that("run_template", {
 test_that("run_template_with_json", {
   mock_output <- list(list(name = 'a', objectId = 1, objectType = 'JSONValue', value = "{'a':1}"))
   mock_post <- mockery::mock(list(id = 1))
-  vals <- with_mock(
-    `civis::scripts_post_custom` =  mock_post,
-    `civis::scripts_post_custom_runs` = function(...) list(id = 1),
-    `civis::scripts_get_custom_runs` = function(...) list(state = 'succeeded'),
-    `civis::jobs_get` = function(...) list(type = 'JobTypes::ContainerDocker', fromTemplateId = 1),
-    `civis::scripts_list_custom_runs_outputs` = function(...) mock_output,
-    run_template(1, arguments = list(arg = 1), credential_id = 1, JSONValue=TRUE)
+  local_mocked_bindings(
+    scripts_post_custom =  mock_post,
+    scripts_post_custom_runs = function(...) list(id = 1),
+    scripts_get_custom_runs = function(...) list(state = 'succeeded'),
+    jobs_get = function(...) list(type = 'JobTypes::ContainerDocker', fromTemplateId = 1),
+    scripts_list_custom_runs_outputs = function(...) mock_output,
   )
+  vals <- run_template(1, arguments = list(arg = 1), credential_id = 1, JSONValue=TRUE)
   expect_equal(vals, "{'a':1}")
   mockery::expect_called(mock_post, 1)
   expect_equal(mockery::mock_args(mock_post)[[1]],
@@ -85,16 +85,16 @@ test_that("run_template_with_json", {
 
 test_that("run_template_with_no_json_output", {
   mock_output <- list(list(name = 'a', objectId = 1, objectType = 'JSONValue', value = "{'a':1}"),
-  	      	      list(name = 'b', objectId = 2, objectType = 'JSONValue', value = "{'b':2}"))
+                      list(name = 'b', objectId = 2, objectType = 'JSONValue', value = "{'b':2}"))
   mock_post <- mockery::mock(list(id = 1))
-  vals <- with_mock(
-    `civis::scripts_post_custom` =  mock_post,
-    `civis::scripts_post_custom_runs` = function(...) list(id = 1),
-    `civis::scripts_get_custom_runs` = function(...) list(state = 'succeeded'),
-    `civis::jobs_get` = function(...) list(type = 'JobTypes::ContainerDocker', fromTemplateId = 1),
-    `civis::scripts_list_custom_runs_outputs` = function(...) mock_output,
-    run_template(1, arguments = list(arg = 1), credential_id = 1, JSONValue=TRUE)
+  local_mocked_bindings(
+    scripts_post_custom =  mock_post,
+    scripts_post_custom_runs = function(...) list(id = 1),
+    scripts_get_custom_runs = function(...) list(state = 'succeeded'),
+    jobs_get = function(...) list(type = 'JobTypes::ContainerDocker', fromTemplateId = 1),
+    scripts_list_custom_runs_outputs = function(...) mock_output,
   )
+  vals <- run_template(1, arguments = list(arg = 1), credential_id = 1, JSONValue = TRUE)
   expect_equal(vals, "{'a':1}")
   mockery::expect_called(mock_post, 1)
   expect_equal(mockery::mock_args(mock_post)[[1]],
@@ -104,14 +104,14 @@ test_that("run_template_with_no_json_output", {
 test_that("run_template_with_multiple_json_output", {
   mock_output <- list(list(name = 'a', objectId = 1, objectType = 'int'))
   mock_post <- mockery::mock(list(id = 1))
-  vals <- with_mock(
-    `civis::scripts_post_custom` =  mock_post,
-    `civis::scripts_post_custom_runs` = function(...) list(id = 1),
-    `civis::scripts_get_custom_runs` = function(...) list(state = 'succeeded'),
-    `civis::jobs_get` = function(...) list(type = 'JobTypes::ContainerDocker', fromTemplateId = 1),
-    `civis::scripts_list_custom_runs_outputs` = function(...) mock_output,
-    run_template(1, arguments = list(arg = 1), credential_id = 1, JSONValue=TRUE)
+  local_mocked_bindings(
+    scripts_post_custom =  mock_post,
+    scripts_post_custom_runs = function(...) list(id = 1),
+    scripts_get_custom_runs = function(...) list(state = 'succeeded'),
+    jobs_get = function(...) list(type = 'JobTypes::ContainerDocker', fromTemplateId = 1),
+    scripts_list_custom_runs_outputs = function(...) mock_output,
   )
+  vals <- run_template(1, arguments = list(arg = 1), credential_id = 1, JSONValue = TRUE)
   expect_equal(vals, NULL)
   mockery::expect_called(mock_post, 1)
   expect_equal(mockery::mock_args(mock_post)[[1]],
@@ -120,10 +120,8 @@ test_that("run_template_with_multiple_json_output", {
 
 test_that("run_civis", {
   # CivisFuture is tested extensively elsewhere.
-  with_mock(
-    `civis::civis_platform` = future::sequential,
-    expect_equal(run_civis(2 + 2), 4)
-  )
+  local_mocked_bindings(civis_platform = future::sequential)
+  expect_equal(run_civis(2 + 2), 4)
 })
 
 test_that("script_get_fun works", {

--- a/tests/testthat/test_tables.R
+++ b/tests/testthat/test_tables.R
@@ -4,43 +4,43 @@ library(civis)
 options(civis.default_db = "sample_db")
 
 test_that("transfer_table succeeds", {
-  res <- with_mock(
-    `civis::default_credential` = function(...) 1,
-    `civis::get_database_id` = function(...) 32,
-    `civis::imports_post` = function(...) list(id = 999),
-    `civis::imports_post_syncs` = function(...) NULL,
-    `civis::imports_post_runs` = function(...) list(runId = 999),
-    `civis::imports_get_files_runs` = function(...) list(state = "succeeded"),
-    transfer_table("db1", "db2", "sc.tb1", "sc.tb2")
+  local_mocked_bindings(
+    default_credential = function(...) 1,
+    get_database_id = function(...) 32,
+    imports_post = function(...) list(id = 999),
+    imports_post_syncs = function(...) NULL,
+    imports_post_runs = function(...) list(runId = 999),
+    imports_get_files_runs = function(...) list(state = "succeeded"),
   )
+  res <- transfer_table("db1", "db2", "sc.tb1", "sc.tb2")
   expect_equal(get_status(res), "succeeded")
 })
 
 test_that("refresh_table succeeds", {
-  with_mock(
-    `civis::get_database_id` = function(...) 32,
-    `civis::get_table_id` = function(...) 5,
-    `civis::tables_post_refresh` = function(...) "",
-    `civis::tables_get` = function(...) list(refreshStatus = "current"),
-    expect_equal(get_status(refresh_table("sea_creatures.whales")), "current")
+  local_mocked_bindings(
+    get_database_id = function(...) 32,
+    get_table_id = function(...) 5,
+    tables_post_refresh = function(...) "",
+    tables_get = function(...) list(refreshStatus = "current"),
   )
+  expect_equal(get_status(refresh_table("sea_creatures.whales")), "current")
 })
 
 test_that("get_table_id returns table id", {
-   with_mock(
-    `civis::get_database_id` = function(...) 32,
-    `civis::tables_list` = function(...) list(list(name = "whales", id = 5)),
-    expect_equal(get_table_id("sea_creatures.whales"), 5)
+  local_mocked_bindings(
+    get_database_id = function(...) 32,
+    tables_list = function(...) list(list(name = "whales", id = 5)),
   )
+  expect_equal(get_table_id("sea_creatures.whales"), 5)
 })
 
 test_that("get_table_id returns error if not found", {
   msg <- paste0("Table sea_creatures.squid not found.")
-  with_mock(
-    `civis::get_database_id` = function(...) 32,
-    `civis::tables_list` = function(...) list(list(name = "whales", id = 5)),
-    expect_error(get_table_id("sea_creatures.squid"), msg)
+  local_mocked_bindings(
+    get_database_id = function(...) 32,
+    tables_list = function(...) list(list(name = "whales", id = 5)),
   )
+  expect_error(get_table_id("sea_creatures.squid"), msg)
 })
 
 test_that("get_table_id returns error if not schema.tablename", {

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -15,23 +15,19 @@ test_that("get_database_id returns a matching id", {
   # simulates a character of class glue often used for
   # string interpolation
   glue_str <- structure("db1", class = c("glue", "character"))
-  with_mock(
-    `civis::databases_list` = function(...) db_list_response,
-    expect_equal(get_database_id(glue_str), 1),
-    expect_equal(get_database_id("db2"), 2)
-  )
+  local_mocked_bindings(databases_list = function(...) db_list_response)
+  expect_equal(get_database_id(glue_str), 1)
+  expect_equal(get_database_id("db2"), 2)
 })
 
 test_that("get_database_id returns an error on no match", {
   e1 <- "Database db4 not found\\. Did you mean redshift-db4\\?"
   e2 <- "Database db5 not found\\. Did you mean DB5\\?"
   e3 <- "Database turkey sandwich not found\\. Did you mean ham sandwich\\?"
-  with_mock(
-    `civis::databases_list` = function(...) db_list_response,
-    expect_error(get_database_id("db4"), e1),
-    expect_error(get_database_id("db5"), e2),
-    expect_error(get_database_id("turkey sandwich"), e3)
-  )
+  local_mocked_bindings(databases_list = function(...) db_list_response)
+  expect_error(get_database_id("db4"), e1)
+  expect_error(get_database_id("db5"), e2)
+  expect_error(get_database_id("turkey sandwich"), e3)
 })
 
 # When `credentials_list(default = TRUE)` the response is a single element list
@@ -41,20 +37,20 @@ credentials_list_response <- list(
 )
 
 test_that("default_credential returns a credential id", {
-  with_mock(
-    `civis::credentials_list` = function(...) credentials_list_response,
-    `civis::get_username` = function() "c",  # used by default_credential
-    expect_equal(default_credential(), 12)
+  local_mocked_bindings(
+    credentials_list = function(...) credentials_list_response,
+    get_username = function() "c",  # used by default_credential,
   )
+  expect_equal(default_credential(), 12)
 })
 
 test_that("get_default_database sets package option for db_list of length 1", {
   options(civis.default_db = NULL)
-  with_mock(
-    `civis::databases_list` = function(...) list(list(id = 555, name = "the_only_db")),
-    db <- get_default_database(),
-    expect_equal(db, "the_only_db")
+  local_mocked_bindings(
+    databases_list = function(...) list(list(id = 555, name = "the_only_db"))
   )
+  db <- get_default_database()
+  expect_equal(db, "the_only_db")
   # test that the option is set as a side-effect
   expect_equal(get_default_database(), "the_only_db")
 })

--- a/tests/testthat/utils.R
+++ b/tests/testthat/utils.R
@@ -24,10 +24,8 @@ check_civis_ml_call <- function(workflow_fn, can_calibrate = TRUE) {
     args[["calibration"]] <- "sigmoid"
   }
 
-  with_mock(
-    `civis::civis_ml` = fake_civis_ml,
-     do.call(workflow_fn, args)
-  )
+  local_mocked_bindings(civis_ml = fake_civis_ml)
+  do.call(workflow_fn, args)
 
   ml_args <- mock_args(fake_civis_ml)[[1]]
   expect_equal(ml_args$x, iris)
@@ -54,13 +52,8 @@ check_civis_ml_call <- function(workflow_fn, can_calibrate = TRUE) {
 
 check_civis_ml_model_type <- function(workflow_fn, workflow_name) {
   fake_civis_ml <- mock(NULL)
-
-  with_mock(
-    `civis::civis_ml` = fake_civis_ml,
-
-    workflow_fn(iris, dependent_variable = "Specis")
-  )
-
+  local_mocked_bindings(civis_ml = fake_civis_ml)
+  workflow_fn(iris, dependent_variable = "Specis")
   ml_args <- mock_args(fake_civis_ml)[[1]]
   expect_equal(ml_args$model_type, workflow_name)
 }

--- a/tools/install-and-run-tests.R
+++ b/tools/install-and-run-tests.R
@@ -1,8 +1,4 @@
 # This script is for running tests in Docker, in Travis CI or locally.
-install.packages(c(
-    "devtools",
-    # Make sure we have a recent version of testthat.
-    "testthat"
-))
+install.packages("devtools")
 devtools::install_local(".", dependencies = TRUE)
 devtools::check()

--- a/tools/install-and-run-tests.R
+++ b/tools/install-and-run-tests.R
@@ -1,4 +1,8 @@
 # This script is for running tests in Docker, in Travis CI or locally.
-install.packages("devtools")
+install.packages(c(
+    "devtools",
+    # Make sure we have a recent version of testthat.
+    "testthat"
+))
 devtools::install_local(".", dependencies = TRUE)
 devtools::check()

--- a/tools/install-and-run-tests.R
+++ b/tools/install-and-run-tests.R
@@ -1,4 +1,6 @@
 # This script is for running tests in Docker, in Travis CI or locally.
 install.packages("devtools")
 devtools::install_local(".", dependencies = TRUE)
-devtools::check()
+# Run the tests separately from the check command so that warnings are logged.
+devtools::test()
+devtools::check(args = "--no-tests")


### PR DESCRIPTION
This replaces [`with_mock()`](https://testthat.r-lib.org/reference/with_mock.html) with [`local_mocked_bindings()`](https://testthat.r-lib.org/reference/local_mocked_bindings.html) since the former is deprecated and won't be available in R 4.5. See #254.