### PR TITLE
REF use support email as the maintainer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,8 @@ Package: civis
 Title: R Client for the 'Civis Platform API'
 Version: 3.1.2
 Authors@R: c(
-  person("Peter", "Cooman", email = "pcooman@civisanalytics.com", role = c("cre", "ctb")),
+  person("Civis", "Support", email = "support@civisanalytics.com", role = "cre"),
+  person("Peter", "Cooman", email = "pcooman@civisanalytics.com", role = "ctb"),
   person("Patrick", "Miller", email = "pmiller@civisanalytics.com", role = "aut"),
   person("Keith", "Ingersoll", email = "kingersoll@civisanalytics.com", role = "aut"),
   person("Bill", "Lattner", email = "wlattner@civisanalytics.com", role = "ctb"),


### PR DESCRIPTION
This package was taken off CRAN because the maintainer is no longer available. Once merged, we can resubmit to CRAN using these [instructions](https://www.r-bloggers.com/2020/07/how-to-write-your-own-r-package-and-publish-it-on-cran/)